### PR TITLE
Mejoras motor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,5 @@ frontend/.env
 
 playwright-report/
 test-results/
+
+backend/app/services/canonical_embeddings.backup.json

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -105,6 +105,7 @@ class SolicitudAnalisisPeriodo(BaseModel):
     resultados_url: str
     periodicidad: str
     col_index: int = 0
+    formato_perfil: str = "vertical_simple"
     period_date: str = ""
     period_label: str = ""
 
@@ -817,12 +818,14 @@ async def analizar_periodo_completo(payload: SolicitudAnalisisPeriodo) -> Dict[s
             resultados_data,
             periodicidad=payload.periodicidad,
             col_index=indice,
+            formato_perfil=payload.formato_perfil,
         )
 
         analisis_liquidez = _calculator.calcular_liquidez(
             balance_data,
             periodicidad=payload.periodicidad,
             col_index=indice,
+            formato_perfil=payload.formato_perfil,
         )
 
         analisis_endeudamiento = _calculator.calcular_endeudamiento(
@@ -830,6 +833,7 @@ async def analizar_periodo_completo(payload: SolicitudAnalisisPeriodo) -> Dict[s
             resultados_data,
             periodicidad=payload.periodicidad,
             col_index=indice,
+            formato_perfil=payload.formato_perfil,
         )
 
         analisis_rotacion = _calculator.calcular_rotacion(
@@ -837,12 +841,14 @@ async def analizar_periodo_completo(payload: SolicitudAnalisisPeriodo) -> Dict[s
             resultados_data,
             periodicidad=payload.periodicidad,
             col_index=indice,
+            formato_perfil=payload.formato_perfil,
         )
 
         analisis_estructura = _calculator.calcular_estructura(
             balance_data,
             periodicidad=payload.periodicidad,
             col_index=indice,
+            formato_perfil=payload.formato_perfil,
         )
 
         # 3. Retornar paquete listo para Dashboard de Vue

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -852,6 +852,9 @@ async def analizar_periodo_completo(payload: SolicitudAnalisisPeriodo) -> Dict[s
         )
 
         # 3. Retornar paquete listo para Dashboard de Vue
+        columnas_balance = _calculator._detect_period_columns(_calculator._get_tables(balance_data))
+        columnas_resultados = _calculator._detect_period_columns(_calculator._get_tables(resultados_data))
+
         return {
             "estatus": "Completado",
             "project_id": payload.project_id,
@@ -863,6 +866,10 @@ async def analizar_periodo_completo(payload: SolicitudAnalisisPeriodo) -> Dict[s
                 "rotacion": analisis_rotacion,
                 "estructura": analisis_estructura,
             },
+            "columnas_detectadas": {
+                "balance": columnas_balance,
+                "resultados": columnas_resultados,
+            },
         }
 
     except HTTPException:
@@ -872,6 +879,39 @@ async def analizar_periodo_completo(payload: SolicitudAnalisisPeriodo) -> Dict[s
         raise HTTPException(
             status_code=500,
             detail=f"Error procesando el periodo: {str(e)}",
+        )
+
+
+class SolicitudDetectarColumnas(BaseModel):
+    balance_url: str
+    resultados_url: str
+
+
+@router.post("/documents/detect-columns")
+async def detectar_columnas_periodo(payload: SolicitudDetectarColumnas) -> Dict[str, Any]:
+    """Devuelve un mapa {periodo: col_index} por cada documento.
+
+    El frontend puede consultar este endpoint ANTES de llamar /analyze-period
+    para saber a qué columna corresponde cada año/mes/trimestre detectado en
+    los headers y así enviar el col_index correcto.
+    """
+    _ensure_firebase_initialized()
+
+    try:
+        balance_data, resultados_data = await asyncio.gather(
+            _azure_service.process_financial_document_async(payload.balance_url),
+            _azure_service.process_financial_document_async(payload.resultados_url),
+        )
+
+        return {
+            "balance": _calculator._detect_period_columns(_calculator._get_tables(balance_data)),
+            "resultados": _calculator._detect_period_columns(_calculator._get_tables(resultados_data)),
+        }
+    except Exception as e:
+        print(f"Error detectando columnas: {str(e)}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Error detectando columnas: {str(e)}",
         )
 
 

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -26,6 +26,37 @@ _calculator = FinancialCalculator()
 _is_initialized = False
 
 
+def _build_period_key(period_date: str, periodicidad: str) -> Optional[str]:
+    """Reconstruye la clave del periodo (mismo formato que el frontend) para
+    cruzar contra la salida de _detect_period_columns.
+
+    Ejemplos:
+      anual + "2024-03"  -> "2024"
+      mensual + "2024-03" -> "2024-03"
+      trimestral + "2024-03" -> "2024-Q1"
+    """
+    if not period_date:
+        return None
+    p = (periodicidad or "").lower().strip()
+    if p == "anual":
+        m = re.search(r"\b(20\d{2})\b", str(period_date))
+        return m.group(1) if m else None
+    parts = str(period_date).split("-")
+    if len(parts) < 2:
+        return None
+    year = parts[0]
+    month = parts[1].zfill(2)
+    if p == "mensual":
+        return f"{year}-{month}"
+    if p == "trimestral":
+        try:
+            q = (int(month) + 2) // 3
+        except ValueError:
+            return None
+        return f"{year}-Q{q}"
+    return None
+
+
 def _ensure_firebase_initialized() -> None:
     global _is_initialized
 
@@ -104,7 +135,9 @@ class SolicitudAnalisisPeriodo(BaseModel):
     balance_url: str
     resultados_url: str
     periodicidad: str
-    col_index: int = 0
+    col_index: int = 0  # legacy; usado si los duales no vienen
+    col_index_balance: Optional[int] = None
+    col_index_resultados: Optional[int] = None
     formato_perfil: str = "vertical_simple"
     period_date: str = ""
     period_label: str = ""
@@ -808,23 +841,45 @@ async def analizar_periodo_completo(payload: SolicitudAnalisisPeriodo) -> Dict[s
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
 
-        indice = payload.col_index
+        # Resolución de col_index dual: si vienen los duales se usan; si no, fallback al legacy.
+        idx_balance = payload.col_index_balance if payload.col_index_balance is not None else payload.col_index
+        idx_resultados = payload.col_index_resultados if payload.col_index_resultados is not None else payload.col_index
+
+        # Detección temprana de columnas + alerta de asimetría
+        columnas_balance = _calculator._detect_period_columns(_calculator._get_tables(balance_data))
+        columnas_resultados = _calculator._detect_period_columns(_calculator._get_tables(resultados_data))
+        periodo_key = _build_period_key(payload.period_date, payload.periodicidad)
+        warning_periodo: Optional[str] = None
+        if periodo_key:
+            en_balance = periodo_key in columnas_balance
+            en_resultados = periodo_key in columnas_resultados
+            if en_balance and not en_resultados and columnas_resultados:
+                warning_periodo = (
+                    f"El periodo '{periodo_key}' aparece en el Balance pero no en el Estado de Resultados. "
+                    "Los KPIs que mezclan ambos documentos pueden estar cruzando periodos distintos."
+                )
+            elif en_resultados and not en_balance and columnas_balance:
+                warning_periodo = (
+                    f"El periodo '{periodo_key}' aparece en el Estado de Resultados pero no en el Balance. "
+                    "Los KPIs que mezclan ambos documentos pueden estar cruzando periodos distintos."
+                )
 
         # 2. Calcular indicadores financieros
-        print("-> Calculando indicadores financieros...")
+        print(f"-> Calculando indicadores financieros (col_index balance={idx_balance}, resultados={idx_resultados})...")
 
         analisis_rentabilidad = _calculator.calcular_rentabilidad(
             balance_data,
             resultados_data,
             periodicidad=payload.periodicidad,
-            col_index=indice,
+            col_index_balance=idx_balance,
+            col_index_resultados=idx_resultados,
             formato_perfil=payload.formato_perfil,
         )
 
         analisis_liquidez = _calculator.calcular_liquidez(
             balance_data,
             periodicidad=payload.periodicidad,
-            col_index=indice,
+            col_index_balance=idx_balance,
             formato_perfil=payload.formato_perfil,
         )
 
@@ -832,7 +887,8 @@ async def analizar_periodo_completo(payload: SolicitudAnalisisPeriodo) -> Dict[s
             balance_data,
             resultados_data,
             periodicidad=payload.periodicidad,
-            col_index=indice,
+            col_index_balance=idx_balance,
+            col_index_resultados=idx_resultados,
             formato_perfil=payload.formato_perfil,
         )
 
@@ -840,22 +896,20 @@ async def analizar_periodo_completo(payload: SolicitudAnalisisPeriodo) -> Dict[s
             balance_data,
             resultados_data,
             periodicidad=payload.periodicidad,
-            col_index=indice,
+            col_index_balance=idx_balance,
+            col_index_resultados=idx_resultados,
             formato_perfil=payload.formato_perfil,
         )
 
         analisis_estructura = _calculator.calcular_estructura(
             balance_data,
             periodicidad=payload.periodicidad,
-            col_index=indice,
+            col_index_balance=idx_balance,
             formato_perfil=payload.formato_perfil,
         )
 
         # 3. Retornar paquete listo para Dashboard de Vue
-        columnas_balance = _calculator._detect_period_columns(_calculator._get_tables(balance_data))
-        columnas_resultados = _calculator._detect_period_columns(_calculator._get_tables(resultados_data))
-
-        return {
+        respuesta = {
             "estatus": "Completado",
             "project_id": payload.project_id,
             "period_id": payload.period_id,
@@ -871,6 +925,10 @@ async def analizar_periodo_completo(payload: SolicitudAnalisisPeriodo) -> Dict[s
                 "resultados": columnas_resultados,
             },
         }
+        if warning_periodo:
+            respuesta["warning_periodo_asimetrico"] = warning_periodo
+            print(f"  ⚠️  {warning_periodo}")
+        return respuesta
 
     except HTTPException:
         raise

--- a/backend/app/services/financial_calculator.py
+++ b/backend/app/services/financial_calculator.py
@@ -210,6 +210,39 @@ class FinancialCalculator:
             "pasivos lp"
         ]
 
+        # ===== Subcuentas para rescate por suma (layouts sin subtotales explícitos) =====
+        self.kw_efectivo = [
+            "efectivo y equivalentes de efectivo",
+            "efectivo y equivalentes",
+            "efectivo", "caja y bancos", "caja", "bancos",
+        ]
+        self.kw_pagos_anticipados = [
+            "seguros anticipados", "pagos anticipados",
+            "gastos pagados por anticipado", "gastos anticipados", "anticipos",
+        ]
+        self.kw_terrenos = ["terrenos", "terreno"]
+        self.kw_maquinaria_equipo = [
+            "maquinaria y equipo", "maquinaria", "edificios",
+            "mobiliario y equipo", "equipo de transporte", "equipo de computo",
+        ]
+        self.kw_depreciacion_acum = [
+            "depreciación acumulada", "depreciacion acumulada",
+            "(-) depreciación acumulada", "(-) depreciacion acumulada",
+            "depreciación y amortización acumulada", "deprec. acum",
+        ]
+        self.kw_proveedores = [
+            "proveedores", "cuentas por pagar a proveedores",
+        ]
+        self.kw_ptu_pagar = ["ptu por pagar", "p.t.u. por pagar"]
+        self.kw_isr_pagar = ["isr por pagar", "i.s.r. por pagar"]
+        self.kw_reservas = ["reservas", "reserva legal", "otras reservas"]
+        self.kw_utilidades_acumuladas = [
+            "utilidades de ejercicios anteriores",
+            "utilidad de ejercicios anteriores",
+            "utilidades acumuladas", "resultados acumulados",
+            "utilid. ejercicios", "utilidades retenidas",
+        ]
+
         # ===== Telemetría de extracción =====
         # _trace_buffer acumula cómo se obtuvo cada concepto en el módulo activo.
         # _last_match_info es la "variable de salida" que _keyword_search/_semantic_search
@@ -509,9 +542,9 @@ class FinancialCalculator:
                                     break
 
                             # Lógica de extracción de columna
-                            if take_last:
-                                return lista_final[-1]
-
+                            # col_index tiene prioridad; take_last es solo fallback
+                            # cuando col_index queda fuera de rango (mantenido por
+                            # _pick_column_value que retorna lista_final[-1] como default).
                             flow_kws = (
                                 getattr(self, "kw_ventas_netas", []) + getattr(self, "kw_utilidad_neta", [])
                                 + getattr(self, "kw_utilidad_antes_impuestos", []) + getattr(self, "kw_utilidad_operacion", [])
@@ -665,8 +698,6 @@ class FinancialCalculator:
         }
 
         lista_final = best_values
-        if take_last:
-            return lista_final[-1]
 
         # --- REGLA FRANCOTIRADOR (Sábanas Mensuales) ---
         p = getattr(self, "_current_periodicidad", "").lower()
@@ -680,13 +711,51 @@ class FinancialCalculator:
                 else:
                     return lista_final[start + step - 1]
 
+        # Respeta col_index primero: en comparativos multi-año la columna elegida
+        # por _detect_period_columns es la fuente de verdad. take_last es fallback
+        # legado para layouts donde el último valor de la fila es el "actual"
+        # (ej. sábanas con columna "Total" al final) y solo aplica si col_index
+        # quedó fuera de rango.
         if col_index < len(lista_final):
             return lista_final[col_index]
-        p = getattr(self, "_current_periodicidad", "").lower()
+
+        if take_last:
+            return lista_final[-1]
+
         if p == "mensual":
             return lista_final[0]
         return lista_final[-1]
 
+
+    def _suma_subcuentas(
+        self,
+        tablas: list,
+        kw_lists_add: List[List[str]],
+        col_index: int,
+        usar_acumulado: bool,
+        multiplicador: float = 1.0,
+        kw_lists_sub: List[List[str]] = None,
+    ) -> float:
+        """Suma subcuentas cuando el subtotal no tiene línea explícita en el documento.
+
+        Solo retorna > 0 si al menos una subcuenta tiene valor, evitando
+        falsos positivos en empresas con subtotales legítimamente en cero.
+        Las listas en kw_lists_sub se restan (ej. depreciación acumulada).
+        """
+        total = 0.0
+        found_any = False
+        for kw_list in kw_lists_add:
+            val = self._find_value(tablas, kw_list, take_last=usar_acumulado, col_index=col_index)
+            if val != 0:
+                found_any = True
+                total += abs(val) * multiplicador
+        if kw_lists_sub:
+            for kw_list in kw_lists_sub:
+                val = self._find_value(tablas, kw_list, take_last=usar_acumulado, col_index=col_index)
+                if val != 0:
+                    found_any = True
+                    total -= abs(val) * multiplicador
+        return max(total, 0.0) if found_any else 0.0
 
     def _record_rescue(self, concept_key: str, formula: str, value: float) -> None:
         """Registra que un rescate matemático calculó/sobreescribió el valor de un concepto."""
@@ -1021,6 +1090,16 @@ class FinancialCalculator:
         activo_total = self._find_value(tablas_balance, self.kw_activo_total, take_last=usar_acumulado, col_index=idx_b, concept_key="activo_total") * multiplicador
         capital_contable = self._find_value(tablas_balance, self.kw_capital, take_last=usar_acumulado, col_index=idx_b, skip_if_row_contains=["pasivo y capital", "pasivo + capital", "pasivo y hacienda"], concept_key="capital_contable") * multiplicador
 
+        if capital_contable == 0:
+            rescatado = self._suma_subcuentas(
+                tablas_balance,
+                [self.kw_capital_social, self.kw_reservas, self.kw_utilidades_acumuladas],
+                idx_b, usar_acumulado, multiplicador,
+            )
+            if rescatado > 0:
+                capital_contable = rescatado
+                self._record_rescue("capital_contable", "suma: capital_social+reservas+utilidades_acum", capital_contable)
+
         # 4) Cálculos
         margen_utilidad = (utilidad_neta / ventas_netas) if ventas_netas else 0
         roa = (utilidad_neta / activo_total) if activo_total else 0
@@ -1091,6 +1170,26 @@ class FinancialCalculator:
         pasivo_circulante = self._find_value(tablas_balance, self.kw_pasivo_circulante, take_last=usar_acumulado, col_index=idx_b, concept_key="pasivo_circulante") * multiplicador
         inventario = self._find_value(tablas_balance, self.kw_inventario, take_last=usar_acumulado, col_index=idx_b, concept_key="inventario") * multiplicador
 
+        if activo_circulante == 0:
+            rescatado = self._suma_subcuentas(
+                tablas_balance,
+                [self.kw_efectivo, self.kw_cuentas_por_cobrar, self.kw_inventario, self.kw_pagos_anticipados],
+                idx_b, usar_acumulado, multiplicador,
+            )
+            if rescatado > 0:
+                activo_circulante = rescatado
+                self._record_rescue("activo_circulante", "suma: efectivo+clientes+inventario+anticipos", activo_circulante)
+
+        if pasivo_circulante == 0:
+            rescatado = self._suma_subcuentas(
+                tablas_balance,
+                [self.kw_proveedores, self.kw_ptu_pagar, self.kw_isr_pagar],
+                idx_b, usar_acumulado, multiplicador,
+            )
+            if rescatado > 0:
+                pasivo_circulante = rescatado
+                self._record_rescue("pasivo_circulante", "suma: proveedores+ptu+isr", pasivo_circulante)
+
         if pasivo_circulante < 0:
             pasivo_circulante = abs(pasivo_circulante)
 
@@ -1154,6 +1253,17 @@ class FinancialCalculator:
 
         # Renombramos a capital_contable para evitar confusiones y asegurar la fórmula
         capital_contable = self._find_value(tablas_balance, self.kw_capital, take_last=usar_acumulado, col_index=idx_b, skip_if_row_contains=["pasivo y capital", "pasivo + capital", "pasivo y hacienda"], concept_key="capital_contable") * multiplicador
+
+        if capital_contable == 0:
+            rescatado = self._suma_subcuentas(
+                tablas_balance,
+                [self.kw_capital_social, self.kw_reservas, self.kw_utilidades_acumuladas],
+                idx_b, usar_acumulado, multiplicador,
+            )
+            if rescatado > 0:
+                capital_contable = rescatado
+                self._record_rescue("capital_contable", "suma: capital_social+reservas+utilidades_acum", capital_contable)
+
         pasivo_total_doc = self._find_value(tablas_balance, self.kw_pasivo_total, take_last=usar_acumulado, col_index=idx_b, skip_if_row_contains=["capital contable", "y capital", "+ capital", "y hacienda"], concept_key="pasivo_total") * multiplicador
 
         # Lógica de rescate para Pasivo Total (Ecuación Contable: P = A - C)
@@ -1252,6 +1362,18 @@ class FinancialCalculator:
         cuentas_por_cobrar = self._find_value(tablas_balance, self.kw_cuentas_por_cobrar, take_last=usar_acumulado, col_index=idx_b, skip_if_row_contains=["nacionales", "extranjeros"], concept_key="cuentas_por_cobrar") * multiplicador
         inventario = self._find_value(tablas_balance, self.kw_inventario, take_last=usar_acumulado, col_index=idx_b, concept_key="inventario") * multiplicador
         activo_fijo_neto = self._find_value(tablas_balance, self.kw_activo_fijo, take_last=usar_acumulado, col_index=idx_b, concept_key="activo_fijo") * multiplicador
+
+        if activo_fijo_neto == 0:
+            rescatado = self._suma_subcuentas(
+                tablas_balance,
+                [self.kw_terrenos, self.kw_maquinaria_equipo],
+                idx_b, usar_acumulado, multiplicador,
+                kw_lists_sub=[self.kw_depreciacion_acum],
+            )
+            if rescatado > 0:
+                activo_fijo_neto = rescatado
+                self._record_rescue("activo_fijo", "suma: terrenos+maquinaria-depreciacion_acum", activo_fijo_neto)
+
         activo_total = self._find_value(tablas_balance, self.kw_activo_total, take_last=usar_acumulado, col_index=idx_b, concept_key="activo_total") * multiplicador
 
         # Usamos nuestra variable dinámica 'usar_acumulado' en lugar del True hardcodeado
@@ -1361,10 +1483,43 @@ class FinancialCalculator:
         # --- 1. EXTRACCIÓN BÁSICA ---
         activo_total = self._find_value(tablas_balance, self.kw_activo_total, take_last=usar_acumulado, col_index=idx_b, concept_key="activo_total") * multiplicador
         activo_fijo = self._find_value(tablas_balance, self.kw_activo_fijo, take_last=usar_acumulado, col_index=idx_b, concept_key="activo_fijo") * multiplicador
+
+        if activo_fijo == 0:
+            rescatado = self._suma_subcuentas(
+                tablas_balance,
+                [self.kw_terrenos, self.kw_maquinaria_equipo],
+                idx_b, usar_acumulado, multiplicador,
+                kw_lists_sub=[self.kw_depreciacion_acum],
+            )
+            if rescatado > 0:
+                activo_fijo = rescatado
+                self._record_rescue("activo_fijo", "suma: terrenos+maquinaria-depreciacion_acum", activo_fijo)
+
         pasivo_total_doc = self._find_value(tablas_balance, self.kw_pasivo_total, take_last=usar_acumulado, col_index=idx_b, skip_if_row_contains=["capital contable", "y capital", "y hacienda"], concept_key="pasivo_total") * multiplicador
         capital_contable = self._find_value(tablas_balance, self.kw_capital, take_last=usar_acumulado, col_index=idx_b, skip_if_row_contains=["pasivo y capital", "pasivo + capital", "pasivo y hacienda", "minoritario", "mayoritario", "minoritaria", "mayoritaria", "participación", "participacion"], concept_key="capital_contable") * multiplicador
+
+        if capital_contable == 0:
+            rescatado = self._suma_subcuentas(
+                tablas_balance,
+                [self.kw_capital_social, self.kw_reservas, self.kw_utilidades_acumuladas],
+                idx_b, usar_acumulado, multiplicador,
+            )
+            if rescatado > 0:
+                capital_contable = rescatado
+                self._record_rescue("capital_contable", "suma: capital_social+reservas+utilidades_acum", capital_contable)
+
         pasivo_largo_plazo = self._find_value(tablas_balance, self.kw_pasivo_largo_plazo, take_last=usar_acumulado, col_index=idx_b, skip_if_row_contains=["capital", "circulante", "corto", "deudores", "acreedores", "clientes", "activo"], concept_key="pasivo_largo_plazo") * multiplicador
         pasivo_circulante = self._find_value(tablas_balance, self.kw_pasivo_circulante, take_last=usar_acumulado, col_index=idx_b, concept_key="pasivo_circulante") * multiplicador
+
+        if pasivo_circulante == 0:
+            rescatado = self._suma_subcuentas(
+                tablas_balance,
+                [self.kw_proveedores, self.kw_ptu_pagar, self.kw_isr_pagar],
+                idx_b, usar_acumulado, multiplicador,
+            )
+            if rescatado > 0:
+                pasivo_circulante = rescatado
+                self._record_rescue("pasivo_circulante", "suma: proveedores+ptu+isr", pasivo_circulante)
 
         # --- 2. LÓGICA INTELIGENTE PARA CAPITAL SOCIAL ---
         capital_social_doc = self._find_value(tablas_balance, self.kw_capital_social, take_last=usar_acumulado, col_index=idx_b, skip_if_row_contains=["pasivo y capital", "pasivo + capital", "pasivo y hacienda", "minoritario", "mayoritario", "contable"]) * multiplicador

--- a/backend/app/services/financial_calculator.py
+++ b/backend/app/services/financial_calculator.py
@@ -338,6 +338,19 @@ class FinancialCalculator:
         dias_map = {"mensual": 30, "trimestral": 90, "semestral": 180}
         return usar_acumulado, dias_map.get(p, 360)
 
+    def _nota_periodo(self, periodicidad: str) -> Optional[str]:
+        """Devuelve la etiqueta sutil para KPIs flujo÷stock cuando el periodo no es anual.
+
+        Aplica a RAT, RSP y las 4 rotaciones: el valor refleja el periodo, no es una tasa anualizada.
+        """
+        p = str(periodicidad).lower().strip()
+        notas = {
+            "mensual": "valor mensual",
+            "trimestral": "valor trimestral",
+            "semestral": "valor semestral",
+        }
+        return notas.get(p)
+
     @staticmethod
     def _get_tables(data: Dict[str, Any]) -> List:
         """Extrae tables_data de un documento de forma segura."""
@@ -733,6 +746,127 @@ class FinancialCalculator:
             return lista_final[0]
         return lista_final[-1]
 
+    # -------------------------------------------------------------------------
+    # Detección de periodo por columna (Fase 8)
+    # -------------------------------------------------------------------------
+    _MESES_ES = {
+        "enero": "01", "ene": "01",
+        "febrero": "02", "feb": "02",
+        "marzo": "03", "mar": "03",
+        "abril": "04", "abr": "04",
+        "mayo": "05", "may": "05",
+        "junio": "06", "jun": "06",
+        "julio": "07", "jul": "07",
+        "agosto": "08", "ago": "08",
+        "septiembre": "09", "sept": "09", "sep": "09",
+        "octubre": "10", "oct": "10",
+        "noviembre": "11", "nov": "11",
+        "diciembre": "12", "dic": "12",
+    }
+
+    def _parse_period_label(self, text: str) -> Optional[str]:
+        """Detecta un periodo en un texto y devuelve etiqueta normalizada.
+
+        Formatos detectados:
+          - "2024"                → "2024"
+          - "Enero 2024"          → "2024-01"
+          - "Dic 2023"            → "2023-12"
+          - "1T24" / "Q1 2024"    → "2024-Q1"
+          - "2024-01" / "01/2024" → "2024-01"
+        """
+        if not text or len(text) < 2:
+            return None
+
+        s = text.strip().lower()
+
+        # Año (20xx)
+        year_match = re.search(r"\b(20\d{2})\b", s)
+        year = year_match.group(1) if year_match else None
+
+        # Año corto al final de patrones tipo "1T24"
+        short_year_match = re.search(r"\b[1-4]\s*[tq]\s*(\d{2})\b", s)
+
+        # Mes (nombre español, completo o abreviado)
+        mes_num: Optional[str] = None
+        for mes_name, num in self._MESES_ES.items():
+            if re.search(rf"\b{mes_name}\b", s):
+                mes_num = num
+                break
+
+        # Fecha numérica: YYYY-MM o MM/YYYY
+        if not mes_num:
+            iso_match = re.search(r"\b(20\d{2})[-/](\d{1,2})\b", s)
+            if iso_match:
+                year = iso_match.group(1)
+                mes_num = iso_match.group(2).zfill(2)
+            else:
+                rev_match = re.search(r"\b(\d{1,2})[-/](20\d{2})\b", s)
+                if rev_match:
+                    mes_num = rev_match.group(1).zfill(2)
+                    year = rev_match.group(2)
+
+        # Trimestre
+        q_num: Optional[str] = None
+        q_match = (
+            re.search(r"\b([1-4])\s*[tq]\s*\d{2,4}\b", s)   # 1T24, 1T 2024
+            or re.search(r"\b([1-4])\s*[tq]\b", s)           # 1T standalone
+            or re.search(r"\b[tq]([1-4])\b", s)              # T1, Q1
+            or re.search(r"trimestre\s+([1-4])", s)          # trimestre 1
+        )
+        if q_match:
+            q_num = q_match.group(1)
+            if not year and short_year_match:
+                year = f"20{short_year_match.group(1)}"
+
+        if mes_num and year:
+            return f"{year}-{mes_num}"
+        if q_num and year:
+            return f"{year}-Q{q_num}"
+        if year:
+            return year
+        return None
+
+    def _detect_period_columns(self, tables_data: List[List[Dict[str, Any]]]) -> Dict[str, int]:
+        """Escanea headers de las tablas y devuelve mapa {periodo: data_col_index}.
+
+        Mira las primeras 3 filas de cada tabla, agrupa el texto por columna
+        (para soportar headers multi-fila tipo "Enero" sobre "2024"), y aplica
+        _parse_period_label a cada combinación.
+
+        El índice devuelto es POSICIONAL entre las columnas de periodo encontradas
+        (0, 1, 2, …), no el índice de celda OCR. Así queda alineado con
+        _find_value, que construye lista_final únicamente con los valores
+        numéricos de la fila (ignorando la celda de etiqueta).
+        """
+        detected: Dict[str, int] = {}
+
+        for table in tables_data:
+            rows: Dict[int, List[Dict[str, Any]]] = {}
+            for cell in table:
+                r_idx = int(cell.get("row", 0))
+                rows.setdefault(r_idx, []).append(cell)
+
+            header_row_ids = sorted(rows.keys())[:3]
+            column_texts: Dict[int, List[str]] = {}
+            for r_idx in header_row_ids:
+                for cell in rows[r_idx]:
+                    col = int(cell.get("col", 0))
+                    text = str(cell.get("text", "")).strip()
+                    if text:
+                        column_texts.setdefault(col, []).append(text)
+
+            data_idx = 0
+            for col in sorted(column_texts.keys()):
+                combined = " ".join(column_texts[col])
+                label = self._parse_period_label(combined)
+                if not label:
+                    continue
+                if label not in detected:
+                    detected[label] = data_idx
+                data_idx += 1
+
+        return detected
+
     def _validate_extractions(
         self,
         values: Dict[str, float],
@@ -893,6 +1027,8 @@ class FinancialCalculator:
         roa_ok = 0.05 * factor
         roe_ok = 0.10 * factor
 
+        nota = self._nota_periodo(periodicidad)
+
         trace = self._collect_trace()
         warnings = self._validate_extractions(
             {"ventas_netas": ventas_netas, "activo_total": activo_total,
@@ -921,11 +1057,13 @@ class FinancialCalculator:
                     "label": "Rendimiento sobre Activos Totales (RAT)",
                     "value": f"{roa * 100:.2f}%",
                     "status": "ok" if roa >= roa_ok else ("warn" if roa >= 0 else "danger"),
+                    **({"nota_periodo": nota} if nota else {}),
                 },
                 {
                     "label": "Rendimiento sobre el Patrimonio",
                     "value": f"{roe * 100:.2f}%",
                     "status": "ok" if roe >= roe_ok else ("warn" if roe >= 0 else "danger"),
+                    **({"nota_periodo": nota} if nota else {}),
                 },
             ],
         }
@@ -1137,6 +1275,8 @@ class FinancialCalculator:
         rot_at_ok = 1.0 * factor
         rot_at_warn = 0.5 * factor
 
+        nota = self._nota_periodo(periodicidad)
+
         trace = self._collect_trace()
         warnings = self._validate_extractions(
             {"activo_total": activo_total, "activo_fijo": activo_fijo_neto,
@@ -1163,6 +1303,7 @@ class FinancialCalculator:
                     "label": "Rotación de la Cartera",
                     "value": f"{rotacion_cartera:.2f}",
                     "status": "ok" if rotacion_cartera >= rot_cartera_ok else ("warn" if rotacion_cartera > 0 else "danger"),
+                    **({"nota_periodo": nota} if nota else {}),
                 },
                 {
                     "label": "Periodo Promedio de Recaudo",
@@ -1173,16 +1314,19 @@ class FinancialCalculator:
                     "label": "Rotación de Inventarios",
                     "value": "N/A" if inventario == 0 else f"{rotacion_inventarios:.2f}",
                     "status": "neutral" if inventario == 0 else ("ok" if rotacion_inventarios > 0 else "danger"),
+                    **({"nota_periodo": nota} if nota and inventario != 0 else {}),
                 },
                 {
                     "label": "Rotación de Activos Fijos",
                     "value": f"{rotacion_activos_fijos:.2f}",
                     "status": "ok" if rotacion_activos_fijos >= rot_af_ok else ("warn" if rotacion_activos_fijos >= rot_af_warn else "danger"),
+                    **({"nota_periodo": nota} if nota else {}),
                 },
                 {
                     "label": "Rotación de Activos Totales",
                     "value": f"{rotacion_activos_totales:.2f}",
                     "status": "ok" if rotacion_activos_totales >= rot_at_ok else ("warn" if rotacion_activos_totales >= rot_at_warn else "danger"),
+                    **({"nota_periodo": nota} if nota else {}),
                 },
             ],
         }

--- a/backend/app/services/financial_calculator.py
+++ b/backend/app/services/financial_calculator.py
@@ -216,9 +216,52 @@ class FinancialCalculator:
         # rellenan antes de retornar, para que _find_value la copie al buffer.
         self._trace_buffer: Dict[str, dict] = {}
         self._last_match_info: dict = {}
+        self._current_formato_perfil: str = "vertical_simple"
+
+        # Marcadores de cuentas compuestas en una sola fila.
+        # Cuando una fila del balance combina dos cuentas NIF distintas (ej.
+        # "Clientes y otras cuentas por cobrar"), no se puede separar el monto
+        # entre los componentes sin información externa — emitimos un warning
+        # para que el usuario sepa que el valor es agregado.
+        # NOTA: "y equivalentes de efectivo" NO está aquí porque la NIF B-6 lo
+        # reconoce como UNA sola cuenta canónica, no como composición.
+        self._composed_markers: List[str] = [
+            " y otras cuentas por cobrar",
+            " y otras cuentas por pagar",
+            " y otros activos",
+            " y otros pasivos",
+            " y otros deudores",
+            " y otros acreedores",
+            " y otras partidas",
+            " e otros activos",
+            " e intangibles",
+        ]
 
         # Cargar catálogo NIF y hacer merge con diccionarios
         self._load_nif_catalog()
+
+        # ===== Fuentes NIF (trazabilidad normativa por concepto canónico) =====
+        self.fuentes_nif: Dict[str, Dict[str, str]] = {
+            # NIF B-3 — Estado de Resultados
+            "ventas_netas":             {"norma": "NIF B-3", "cuenta_nif": "Ventas o Ingresos netos"},
+            "costo_de_ventas":          {"norma": "NIF B-3", "cuenta_nif": "Costo de ventas"},
+            "utilidad_operacion":       {"norma": "NIF B-3", "cuenta_nif": "Utilidad de operación"},
+            "gastos_financieros":       {"norma": "NIF B-3", "cuenta_nif": "Gastos financieros (Intereses a cargo)"},
+            "utilidad_antes_impuestos": {"norma": "NIF B-3", "cuenta_nif": "Utilidad antes de impuestos a la utilidad"},
+            "impuestos":                {"norma": "NIF B-3", "cuenta_nif": "Impuestos a la utilidad"},
+            "utilidad_neta":            {"norma": "NIF B-3", "cuenta_nif": "Utilidad / pérdida del ejercicio"},
+            # NIF B-6 — Estado de Situación Financiera
+            "activo_circulante":        {"norma": "NIF B-6", "cuenta_nif": "Activo a corto plazo (circulante)"},
+            "cuentas_por_cobrar":       {"norma": "NIF B-6", "cuenta_nif": "Cuentas por cobrar a clientes"},
+            "inventario":               {"norma": "NIF B-6", "cuenta_nif": "Inventarios"},
+            "activo_fijo":              {"norma": "NIF B-6", "cuenta_nif": "Propiedades, planta y equipo"},
+            "activo_total":             {"norma": "NIF B-6", "cuenta_nif": "Total del Activo"},
+            "pasivo_circulante":        {"norma": "NIF B-6", "cuenta_nif": "Pasivo a corto plazo"},
+            "pasivo_largo_plazo":       {"norma": "NIF B-6", "cuenta_nif": "Pasivo a largo plazo"},
+            "pasivo_total":             {"norma": "NIF B-6", "cuenta_nif": "Total del Pasivo"},
+            "capital_social":           {"norma": "NIF B-6", "cuenta_nif": "Capital social"},
+            "capital_contable":         {"norma": "NIF B-6", "cuenta_nif": "Capital Contable"},
+        }
 
     # -------------------------------------------------------------------------
     # Helpers internos
@@ -422,6 +465,18 @@ class FinancialCalculator:
                             # --- FILTRO ANTI-PORCENTAJES (Nivel Experto) ---
                             max_magnitude = max(abs(v) for v in found_values)
 
+                            # Detectar columna de % al final: si hay 3+ valores y el
+                            # último es < 1% del máximo en magnitud, es una columna de
+                            # variación/porcentaje (ej. -251.17% en GCMK vs -324,525.87).
+                            # Cubre % > 100 que el filtro >100 no puede descartar.
+                            if (
+                                len(found_values) >= 3
+                                and max_magnitude > 0
+                                and abs(found_values[-1]) < max_magnitude * 0.01
+                            ):
+                                found_values = found_values[:-1]
+                                max_magnitude = max(abs(v) for v in found_values)
+
                             val_monetarios = [v for v in found_values if abs(v) > 100 or abs(v) == max_magnitude or v == 0]
 
                             # Determinamos la lista a usar
@@ -433,32 +488,26 @@ class FinancialCalculator:
                                 "matched_term": kw,
                                 "row_snippet": row_text[:120].strip(),
                             }
+                            # Detección de cuenta compuesta (ej. "Clientes y otras cuentas por cobrar")
+                            for marker in self._composed_markers:
+                                if marker in row_text:
+                                    self._last_match_info["composed"] = True
+                                    self._last_match_info["composed_marker"] = marker.strip()
+                                    break
 
                             # Lógica de extracción de columna
                             if take_last:
                                 return lista_final[-1]
-                            
-                            # --- REGLA FRANCOTIRADOR (Sábanas Mensuales) ---
-                            p = getattr(self, "_current_periodicidad", "").lower()
-                            if len(lista_final) >= 12 and p in ("trimestral", "semestral"):
-                                flow_kws = getattr(self, "kw_ventas_netas", []) + getattr(self, "kw_utilidad_neta", []) + getattr(self, "kw_utilidad_antes_impuestos", []) + getattr(self, "kw_utilidad_operacion", []) + getattr(self, "kw_costo_de_ventas", []) + getattr(self, "kw_intereses", []) + getattr(self, "kw_impuestos", []) + getattr(self, "kw_compras", []) + getattr(self, "kw_devoluciones_costo", []) + ["ingresos"]
-                                is_flow = any(kw in flow_kws for kw in keywords)
-                                step = 3 if p == "trimestral" else 6
-                                start = col_index * step
-                                if start + step <= len(lista_final):
-                                    if is_flow:
-                                        return sum(lista_final[start:start+step])
-                                    else:
-                                        return lista_final[start + step - 1]
 
-                            # Usamos el col_index para elegir la columna deseada
-                            if col_index < len(lista_final):
-                                return lista_final[col_index]
-                            else:
-                                p = getattr(self, "_current_periodicidad", "").lower()
-                                if p == "mensual":
-                                    return lista_final[0]
-                                return lista_final[-1]
+                            flow_kws = (
+                                getattr(self, "kw_ventas_netas", []) + getattr(self, "kw_utilidad_neta", [])
+                                + getattr(self, "kw_utilidad_antes_impuestos", []) + getattr(self, "kw_utilidad_operacion", [])
+                                + getattr(self, "kw_costo_de_ventas", []) + getattr(self, "kw_intereses", [])
+                                + getattr(self, "kw_impuestos", []) + getattr(self, "kw_compras", [])
+                                + getattr(self, "kw_devoluciones_costo", []) + ["ingresos"]
+                            )
+                            is_flow = any(kw in flow_kws for kw in keywords)
+                            return self._pick_column_value(lista_final, col_index, is_flow)
 
                         # Fallback si texto y número están pegados en la misma celda
                         for cell in row_cells:
@@ -495,6 +544,7 @@ class FinancialCalculator:
         best_raw = 0.0
         best_anti = 0.0
         best_values = []
+        best_row_label = ""
 
         for table in reversed(tables_data):
             rows: Dict[int, List[Dict[str, Any]]] = {}
@@ -532,6 +582,7 @@ class FinancialCalculator:
                     best_adjusted = score_adj
                     best_raw = score_raw
                     best_anti = score_anti
+                    best_row_label = row_label
                     # Extraer valores numéricos de la fila
                     text_col_max = -1
                     for c in row_cells:
@@ -552,6 +603,15 @@ class FinancialCalculator:
 
                     if found_values:
                         max_magnitude = max(abs(v) for v in found_values)
+                        # Mismo filtro anti-porcentajes que _keyword_search:
+                        # columna de % al final con magnitud < 1% del max.
+                        if (
+                            len(found_values) >= 3
+                            and max_magnitude > 0
+                            and abs(found_values[-1]) < max_magnitude * 0.01
+                        ):
+                            found_values = found_values[:-1]
+                            max_magnitude = max(abs(v) for v in found_values)
                         val_monetarios = [v for v in found_values if abs(v) > 100 or abs(v) == max_magnitude or v == 0]
                         best_values = val_monetarios if val_monetarios else found_values
 
@@ -588,6 +648,7 @@ class FinancialCalculator:
             "score_adjusted": round(best_adjusted, 4),
             "score_anti": round(best_anti, 4),
             "zone": zona,
+            "row_snippet": best_row_label[:120],
         }
 
         lista_final = best_values
@@ -630,6 +691,47 @@ class FinancialCalculator:
         trace = dict(self._trace_buffer) if self._trace_buffer else None
         self._trace_buffer.clear()
         return trace
+
+    def _collect_fuentes(self, concept_keys: List[str]) -> Dict[str, Dict[str, str]]:
+        """Retorna las fuentes NIF para los conceptos usados en el módulo."""
+        return {k: self.fuentes_nif[k] for k in concept_keys if k in self.fuentes_nif}
+
+    def _pick_column_value(self, lista_final: List[float], col_index: int, is_flow: bool = False) -> float:
+        """Selecciona el valor correcto de lista_final según el perfil de formato activo.
+
+        Perfiles:
+          - sabana_mensual   : francotirador explícito (col_index navega grupos de meses)
+          - corporativo_bmv  : col_index directo, nunca activa el francotirador
+          - vertical_simple  : col_index directo + heurística legacy (len>=12) para compatibilidad
+          - lado_a_lado      : col_index directo (el stop-at-text ya filtró el lado correcto)
+        """
+        perfil = getattr(self, "_current_formato_perfil", "vertical_simple")
+        p = getattr(self, "_current_periodicidad", "").lower()
+
+        if perfil == "sabana_mensual":
+            step = 3 if p == "trimestral" else 6
+            start = col_index * step
+            if start + step <= len(lista_final):
+                return sum(lista_final[start:start + step]) if is_flow else lista_final[start + step - 1]
+            return lista_final[0]
+
+        if perfil == "corporativo_bmv":
+            if col_index < len(lista_final):
+                return lista_final[col_index]
+            return lista_final[-1]
+
+        # vertical_simple y lado_a_lado: mantener heurística legacy para compatibilidad
+        if len(lista_final) >= 12 and p in ("trimestral", "semestral"):
+            step = 3 if p == "trimestral" else 6
+            start = col_index * step
+            if start + step <= len(lista_final):
+                return sum(lista_final[start:start + step]) if is_flow else lista_final[start + step - 1]
+
+        if col_index < len(lista_final):
+            return lista_final[col_index]
+        if p == "mensual":
+            return lista_final[0]
+        return lista_final[-1]
 
     def _validate_extractions(
         self,
@@ -716,6 +818,16 @@ class FinancialCalculator:
         if vn < 0:
             warnings.append(f"ventas_netas negativas ({vn:,.2f}) — revisar extracción")
 
+        # 5. Cuentas compuestas: informativo, no bloqueante
+        for concept_key, info in tr.items():
+            if info.get("composed"):
+                marker = info.get("composed_marker", "")
+                warnings.append(
+                    f"{concept_key}: valor extraído de una cuenta compuesta "
+                    f"(fila contiene '{marker}'). Incluye sub-cuentas que no pueden "
+                    f"separarse sin información adicional."
+                )
+
         if warnings:
             for w in warnings:
                 print(f"  ⚠️  Validación    : {w}")
@@ -737,10 +849,11 @@ class FinancialCalculator:
     # -------------------------------------------------------------------------
     # KPIs
     # -------------------------------------------------------------------------
-    def calcular_rentabilidad(self, balance_data: Dict[str, Any], resultados_data: Dict[str, Any], periodicidad: str = "anual", col_index: int = 0) -> Dict[str, Any]:
+    def calcular_rentabilidad(self, balance_data: Dict[str, Any], resultados_data: Dict[str, Any], periodicidad: str = "anual", col_index: int = 0, formato_perfil: str = "vertical_simple") -> Dict[str, Any]:
         """Calcula indicadores de rentabilidad cruzando Balance y Estado de Resultados."""
         self._trace_buffer.clear()
         self._current_periodicidad = periodicidad
+        self._current_formato_perfil = formato_perfil
         tablas_resultados = self._get_tables(resultados_data)
         tablas_balance = self._get_tables(balance_data)
         usar_acumulado, dias_periodo = self._parse_periodicidad(periodicidad)
@@ -796,6 +909,7 @@ class FinancialCalculator:
                 "multiplicador": multiplicador,
                 "_extraction_trace": trace,
                 "_warnings": warnings,
+                "fuentes": self._collect_fuentes(["utilidad_neta", "ventas_netas", "activo_total", "capital_contable"]),
             },
             "kpis": [
                 {
@@ -816,10 +930,11 @@ class FinancialCalculator:
             ],
         }
 
-    def calcular_liquidez(self, balance_data: Dict[str, Any], periodicidad: str = "anual", col_index: int = 0) -> Dict[str, Any]:
+    def calcular_liquidez(self, balance_data: Dict[str, Any], periodicidad: str = "anual", col_index: int = 0, formato_perfil: str = "vertical_simple") -> Dict[str, Any]:
         """Calcula indicadores de liquidez usando únicamente el Balance General."""
         self._trace_buffer.clear()
         self._current_periodicidad = periodicidad
+        self._current_formato_perfil = formato_perfil
         tablas_balance = self._get_tables(balance_data)
         usar_acumulado, _ = self._parse_periodicidad(periodicidad)
         
@@ -852,6 +967,7 @@ class FinancialCalculator:
                 "multiplicador": multiplicador,
                 "_extraction_trace": trace,
                 "_warnings": warnings,
+                "fuentes": self._collect_fuentes(["activo_circulante", "pasivo_circulante", "inventario"]),
             },
             "kpis": [
                 {
@@ -872,10 +988,11 @@ class FinancialCalculator:
             ],
         }
 
-    def calcular_endeudamiento(self, balance_data: Dict[str, Any], resultados_data: Dict[str, Any], periodicidad: str = "anual", col_index: int = 0) -> Dict[str, Any]:
+    def calcular_endeudamiento(self, balance_data: Dict[str, Any], resultados_data: Dict[str, Any], periodicidad: str = "anual", col_index: int = 0, formato_perfil: str = "vertical_simple") -> Dict[str, Any]:
         """Calcula indicadores de endeudamiento cruzando Balance y Estado de Resultados."""
         self._trace_buffer.clear()
         self._current_periodicidad = periodicidad
+        self._current_formato_perfil = formato_perfil
         tablas_balance = self._get_tables(balance_data)
         tablas_resultados = self._get_tables(resultados_data)
         usar_acumulado, _ = self._parse_periodicidad(periodicidad)
@@ -904,7 +1021,7 @@ class FinancialCalculator:
 
         # --- EXTRACCIÓN DEL ESTADO DE RESULTADOS ---
         utilidad_operacion = self._find_value(tablas_resultados, self.kw_utilidad_operacion, take_last=usar_acumulado, col_index=col_index, skip_if_row_contains=["neta", "total", "ejercicio", "antes de", "cambiaria", "bruta", "financier"], concept_key="utilidad_operacion") * multiplicador
-        intereses = self._find_value(tablas_resultados, self.kw_intereses, take_last=usar_acumulado, col_index=col_index, concept_key="gastos_financieros") * multiplicador
+        intereses = self._find_value(tablas_resultados, self.kw_intereses, take_last=usar_acumulado, col_index=col_index, concept_key="gastos_financieros", skip_if_row_contains=["de operacion", "operativos", "de venta", "de administracion"]) * multiplicador
         utilidad_neta = self._find_value(tablas_resultados, self.kw_utilidad_neta, take_last=usar_acumulado, col_index=col_index, skip_if_row_contains=["atribuible", "controladora", "no controladora", "minoritaria", "mayoritaria", "participación", "participacion"], concept_key="utilidad_neta") * multiplicador
         impuestos = self._find_value(tablas_resultados, self.kw_impuestos, take_last=usar_acumulado, col_index=col_index, concept_key="impuestos") * multiplicador
         
@@ -946,6 +1063,7 @@ class FinancialCalculator:
                 "multiplicador": multiplicador,
                 "_extraction_trace": trace,
                 "_warnings": warnings,
+                "fuentes": self._collect_fuentes(["pasivo_total", "activo_total", "capital_contable", "utilidad_operacion", "gastos_financieros", "utilidad_neta", "impuestos"]),
             },
             "kpis": [
                 {
@@ -966,10 +1084,11 @@ class FinancialCalculator:
             ],
         }
 
-    def calcular_rotacion(self, balance_data: Dict[str, Any], resultados_data: Dict[str, Any], periodicidad: str = "anual", col_index: int = 0) -> Dict[str, Any]:
+    def calcular_rotacion(self, balance_data: Dict[str, Any], resultados_data: Dict[str, Any], periodicidad: str = "anual", col_index: int = 0, formato_perfil: str = "vertical_simple") -> Dict[str, Any]:
         """Calcula indicadores de rotación adaptándose dinámicamente al tipo de periodo."""
         self._trace_buffer.clear()
         self._current_periodicidad = periodicidad
+        self._current_formato_perfil = formato_perfil
         tablas_balance = self._get_tables(balance_data)
         tablas_resultados = self._get_tables(resultados_data)
         usar_acumulado, dias_periodo = self._parse_periodicidad(periodicidad)
@@ -1037,6 +1156,7 @@ class FinancialCalculator:
                 "multiplicador": multiplicador,
                 "_extraction_trace": trace,
                 "_warnings": warnings,
+                "fuentes": self._collect_fuentes(["cuentas_por_cobrar", "inventario", "activo_fijo", "activo_total", "ventas_netas", "costo_de_ventas"]),
             },
             "kpis": [
                 {
@@ -1067,10 +1187,11 @@ class FinancialCalculator:
             ],
         }
 
-    def calcular_estructura(self, balance_data: Dict[str, Any], periodicidad: str = "anual", col_index: int = 0) -> Dict[str, Any]:
+    def calcular_estructura(self, balance_data: Dict[str, Any], periodicidad: str = "anual", col_index: int = 0, formato_perfil: str = "vertical_simple") -> Dict[str, Any]:
         """Calcula indicadores de estructura financiera basándose en el Balance General."""
         self._trace_buffer.clear()
         self._current_periodicidad = periodicidad
+        self._current_formato_perfil = formato_perfil
         tablas_balance = self._get_tables(balance_data)
         usar_acumulado, _ = self._parse_periodicidad(periodicidad)
         
@@ -1154,6 +1275,7 @@ class FinancialCalculator:
                 "multiplicador": multiplicador,
                 "_extraction_trace": trace,
                 "_warnings": warnings,
+                "fuentes": self._collect_fuentes(["activo_total", "pasivo_total", "capital_social", "capital_contable", "activo_fijo", "pasivo_largo_plazo", "pasivo_circulante"]),
             },
             "kpis": [
                 {

--- a/backend/app/services/financial_calculator.py
+++ b/backend/app/services/financial_calculator.py
@@ -983,36 +983,43 @@ class FinancialCalculator:
     # -------------------------------------------------------------------------
     # KPIs
     # -------------------------------------------------------------------------
-    def calcular_rentabilidad(self, balance_data: Dict[str, Any], resultados_data: Dict[str, Any], periodicidad: str = "anual", col_index: int = 0, formato_perfil: str = "vertical_simple") -> Dict[str, Any]:
-        """Calcula indicadores de rentabilidad cruzando Balance y Estado de Resultados."""
+    def calcular_rentabilidad(self, balance_data: Dict[str, Any], resultados_data: Dict[str, Any], periodicidad: str = "anual", col_index: int = 0, formato_perfil: str = "vertical_simple", col_index_balance: Optional[int] = None, col_index_resultados: Optional[int] = None) -> Dict[str, Any]:
+        """Calcula indicadores de rentabilidad cruzando Balance y Estado de Resultados.
+
+        col_index_balance / col_index_resultados: índices independientes por documento (recomendado).
+        col_index: valor legacy usado como fallback si los duales no se proveen.
+        """
         self._trace_buffer.clear()
         self._current_periodicidad = periodicidad
         self._current_formato_perfil = formato_perfil
         tablas_resultados = self._get_tables(resultados_data)
         tablas_balance = self._get_tables(balance_data)
         usar_acumulado, dias_periodo = self._parse_periodicidad(periodicidad)
-        
-        multiplicador = max(self._detect_scale(balance_data), self._detect_scale(resultados_data))
-        ventas_netas = self._find_value(tablas_resultados, self.kw_ventas_netas, take_last=usar_acumulado, col_index=col_index, concept_key="ventas_netas") * multiplicador
-        if ventas_netas == 0:
-            ventas_netas = self._find_value(tablas_resultados, ["ingresos"], take_last=usar_acumulado, col_index=col_index) * multiplicador
 
-        utilidad_neta = self._find_value(tablas_resultados, self.kw_utilidad_neta, take_last=usar_acumulado, col_index=col_index, skip_if_row_contains=["atribuible", "controladora", "no controladora", "minoritaria", "mayoritaria", "participación", "participacion"], concept_key="utilidad_neta") * multiplicador
-        
+        idx_b = col_index_balance if col_index_balance is not None else col_index
+        idx_r = col_index_resultados if col_index_resultados is not None else col_index
+
+        multiplicador = max(self._detect_scale(balance_data), self._detect_scale(resultados_data))
+        ventas_netas = self._find_value(tablas_resultados, self.kw_ventas_netas, take_last=usar_acumulado, col_index=idx_r, concept_key="ventas_netas") * multiplicador
+        if ventas_netas == 0:
+            ventas_netas = self._find_value(tablas_resultados, ["ingresos"], take_last=usar_acumulado, col_index=idx_r) * multiplicador
+
+        utilidad_neta = self._find_value(tablas_resultados, self.kw_utilidad_neta, take_last=usar_acumulado, col_index=idx_r, skip_if_row_contains=["atribuible", "controladora", "no controladora", "minoritaria", "mayoritaria", "participación", "participacion"], concept_key="utilidad_neta") * multiplicador
+
         # Fallback 1: buscar utilidad antes de impuestos en el Estado de Resultados
         if utilidad_neta == 0:
-            utilidad_neta = self._find_value(tablas_resultados, self.kw_utilidad_antes_impuestos, take_last=usar_acumulado, col_index=col_index, concept_key="utilidad_antes_impuestos") * multiplicador
+            utilidad_neta = self._find_value(tablas_resultados, self.kw_utilidad_antes_impuestos, take_last=usar_acumulado, col_index=idx_r, concept_key="utilidad_antes_impuestos") * multiplicador
 
         # Fallback 2: buscar utilidad neta en el Balance General
         if utilidad_neta == 0:
-            utilidad_neta = self._find_value(tablas_balance, self.kw_utilidad_neta, take_last=usar_acumulado, col_index=0) * multiplicador
-            
+            utilidad_neta = self._find_value(tablas_balance, self.kw_utilidad_neta, take_last=usar_acumulado, col_index=idx_b) * multiplicador
+
         if utilidad_neta == 0:
-                utilidad_neta = self._find_value(tablas_balance, self.kw_utilidad_antes_impuestos, take_last=usar_acumulado, col_index=0) * multiplicador
+                utilidad_neta = self._find_value(tablas_balance, self.kw_utilidad_antes_impuestos, take_last=usar_acumulado, col_index=idx_b) * multiplicador
 
         # 3) Balance
-        activo_total = self._find_value(tablas_balance, self.kw_activo_total, take_last=usar_acumulado, col_index=0, concept_key="activo_total") * multiplicador
-        capital_contable = self._find_value(tablas_balance, self.kw_capital, take_last=usar_acumulado, col_index=0, skip_if_row_contains=["pasivo y capital", "pasivo + capital", "pasivo y hacienda"], concept_key="capital_contable") * multiplicador
+        activo_total = self._find_value(tablas_balance, self.kw_activo_total, take_last=usar_acumulado, col_index=idx_b, concept_key="activo_total") * multiplicador
+        capital_contable = self._find_value(tablas_balance, self.kw_capital, take_last=usar_acumulado, col_index=idx_b, skip_if_row_contains=["pasivo y capital", "pasivo + capital", "pasivo y hacienda"], concept_key="capital_contable") * multiplicador
 
         # 4) Cálculos
         margen_utilidad = (utilidad_neta / ventas_netas) if ventas_netas else 0
@@ -1068,19 +1075,21 @@ class FinancialCalculator:
             ],
         }
 
-    def calcular_liquidez(self, balance_data: Dict[str, Any], periodicidad: str = "anual", col_index: int = 0, formato_perfil: str = "vertical_simple") -> Dict[str, Any]:
+    def calcular_liquidez(self, balance_data: Dict[str, Any], periodicidad: str = "anual", col_index: int = 0, formato_perfil: str = "vertical_simple", col_index_balance: Optional[int] = None) -> Dict[str, Any]:
         """Calcula indicadores de liquidez usando únicamente el Balance General."""
         self._trace_buffer.clear()
         self._current_periodicidad = periodicidad
         self._current_formato_perfil = formato_perfil
         tablas_balance = self._get_tables(balance_data)
         usar_acumulado, _ = self._parse_periodicidad(periodicidad)
-        
+
+        idx_b = col_index_balance if col_index_balance is not None else col_index
+
         multiplicador = self._detect_scale(balance_data)
 
-        activo_circulante = self._find_value(tablas_balance, self.kw_activo_circulante, take_last=usar_acumulado, col_index=0, concept_key="activo_circulante") * multiplicador
-        pasivo_circulante = self._find_value(tablas_balance, self.kw_pasivo_circulante, take_last=usar_acumulado, col_index=0, concept_key="pasivo_circulante") * multiplicador
-        inventario = self._find_value(tablas_balance, self.kw_inventario, take_last=usar_acumulado, col_index=0, concept_key="inventario") * multiplicador
+        activo_circulante = self._find_value(tablas_balance, self.kw_activo_circulante, take_last=usar_acumulado, col_index=idx_b, concept_key="activo_circulante") * multiplicador
+        pasivo_circulante = self._find_value(tablas_balance, self.kw_pasivo_circulante, take_last=usar_acumulado, col_index=idx_b, concept_key="pasivo_circulante") * multiplicador
+        inventario = self._find_value(tablas_balance, self.kw_inventario, take_last=usar_acumulado, col_index=idx_b, concept_key="inventario") * multiplicador
 
         if pasivo_circulante < 0:
             pasivo_circulante = abs(pasivo_circulante)
@@ -1126,7 +1135,7 @@ class FinancialCalculator:
             ],
         }
 
-    def calcular_endeudamiento(self, balance_data: Dict[str, Any], resultados_data: Dict[str, Any], periodicidad: str = "anual", col_index: int = 0, formato_perfil: str = "vertical_simple") -> Dict[str, Any]:
+    def calcular_endeudamiento(self, balance_data: Dict[str, Any], resultados_data: Dict[str, Any], periodicidad: str = "anual", col_index: int = 0, formato_perfil: str = "vertical_simple", col_index_balance: Optional[int] = None, col_index_resultados: Optional[int] = None) -> Dict[str, Any]:
         """Calcula indicadores de endeudamiento cruzando Balance y Estado de Resultados."""
         self._trace_buffer.clear()
         self._current_periodicidad = periodicidad
@@ -1134,15 +1143,18 @@ class FinancialCalculator:
         tablas_balance = self._get_tables(balance_data)
         tablas_resultados = self._get_tables(resultados_data)
         usar_acumulado, _ = self._parse_periodicidad(periodicidad)
-        
+
+        idx_b = col_index_balance if col_index_balance is not None else col_index
+        idx_r = col_index_resultados if col_index_resultados is not None else col_index
+
         multiplicador = max(self._detect_scale(balance_data), self._detect_scale(resultados_data))
 
         # --- EXTRACCIÓN DEL BALANCE ---
-        activo_total = self._find_value(tablas_balance, self.kw_activo_total, take_last=usar_acumulado, col_index=0, concept_key="activo_total") * multiplicador
-        
+        activo_total = self._find_value(tablas_balance, self.kw_activo_total, take_last=usar_acumulado, col_index=idx_b, concept_key="activo_total") * multiplicador
+
         # Renombramos a capital_contable para evitar confusiones y asegurar la fórmula
-        capital_contable = self._find_value(tablas_balance, self.kw_capital, take_last=usar_acumulado, col_index=0, skip_if_row_contains=["pasivo y capital", "pasivo + capital", "pasivo y hacienda"], concept_key="capital_contable") * multiplicador
-        pasivo_total_doc = self._find_value(tablas_balance, self.kw_pasivo_total, take_last=usar_acumulado, col_index=0, skip_if_row_contains=["capital contable", "y capital", "+ capital", "y hacienda"], concept_key="pasivo_total") * multiplicador
+        capital_contable = self._find_value(tablas_balance, self.kw_capital, take_last=usar_acumulado, col_index=idx_b, skip_if_row_contains=["pasivo y capital", "pasivo + capital", "pasivo y hacienda"], concept_key="capital_contable") * multiplicador
+        pasivo_total_doc = self._find_value(tablas_balance, self.kw_pasivo_total, take_last=usar_acumulado, col_index=idx_b, skip_if_row_contains=["capital contable", "y capital", "+ capital", "y hacienda"], concept_key="pasivo_total") * multiplicador
 
         # Lógica de rescate para Pasivo Total (Ecuación Contable: P = A - C)
         # Si no lo encuentra (0) o si captura la fila "Total Pasivo + Capital" (>= activo_total)
@@ -1158,18 +1170,18 @@ class FinancialCalculator:
 
 
         # --- EXTRACCIÓN DEL ESTADO DE RESULTADOS ---
-        utilidad_operacion = self._find_value(tablas_resultados, self.kw_utilidad_operacion, take_last=usar_acumulado, col_index=col_index, skip_if_row_contains=["neta", "total", "ejercicio", "antes de", "cambiaria", "bruta", "financier"], concept_key="utilidad_operacion") * multiplicador
-        intereses = self._find_value(tablas_resultados, self.kw_intereses, take_last=usar_acumulado, col_index=col_index, concept_key="gastos_financieros", skip_if_row_contains=["de operacion", "operativos", "de venta", "de administracion"]) * multiplicador
-        utilidad_neta = self._find_value(tablas_resultados, self.kw_utilidad_neta, take_last=usar_acumulado, col_index=col_index, skip_if_row_contains=["atribuible", "controladora", "no controladora", "minoritaria", "mayoritaria", "participación", "participacion"], concept_key="utilidad_neta") * multiplicador
-        impuestos = self._find_value(tablas_resultados, self.kw_impuestos, take_last=usar_acumulado, col_index=col_index, concept_key="impuestos") * multiplicador
-        
+        utilidad_operacion = self._find_value(tablas_resultados, self.kw_utilidad_operacion, take_last=usar_acumulado, col_index=idx_r, skip_if_row_contains=["neta", "total", "ejercicio", "antes de", "cambiaria", "bruta", "financier"], concept_key="utilidad_operacion") * multiplicador
+        intereses = self._find_value(tablas_resultados, self.kw_intereses, take_last=usar_acumulado, col_index=idx_r, concept_key="gastos_financieros", skip_if_row_contains=["de operacion", "operativos", "de venta", "de administracion"]) * multiplicador
+        utilidad_neta = self._find_value(tablas_resultados, self.kw_utilidad_neta, take_last=usar_acumulado, col_index=idx_r, skip_if_row_contains=["atribuible", "controladora", "no controladora", "minoritaria", "mayoritaria", "participación", "participacion"], concept_key="utilidad_neta") * multiplicador
+        impuestos = self._find_value(tablas_resultados, self.kw_impuestos, take_last=usar_acumulado, col_index=idx_r, concept_key="impuestos") * multiplicador
+
         if intereses < 0: intereses = abs(intereses)
         if impuestos < 0: impuestos = abs(impuestos)
 
         # --- LÓGICA DE RESCATE (100% UNIVERSAL Y MATEMÁTICA) ---
         if utilidad_operacion == 0 or utilidad_operacion == intereses:
             # Rescate Nivel 1: EBT + Intereses
-            util_antes_imp = self._find_value(tablas_resultados, self.kw_utilidad_antes_impuestos, take_last=usar_acumulado, col_index=col_index, concept_key="utilidad_antes_impuestos") * multiplicador
+            util_antes_imp = self._find_value(tablas_resultados, self.kw_utilidad_antes_impuestos, take_last=usar_acumulado, col_index=idx_r, concept_key="utilidad_antes_impuestos") * multiplicador
 
             if util_antes_imp != 0:
                 utilidad_operacion = util_antes_imp + intereses
@@ -1222,7 +1234,7 @@ class FinancialCalculator:
             ],
         }
 
-    def calcular_rotacion(self, balance_data: Dict[str, Any], resultados_data: Dict[str, Any], periodicidad: str = "anual", col_index: int = 0, formato_perfil: str = "vertical_simple") -> Dict[str, Any]:
+    def calcular_rotacion(self, balance_data: Dict[str, Any], resultados_data: Dict[str, Any], periodicidad: str = "anual", col_index: int = 0, formato_perfil: str = "vertical_simple", col_index_balance: Optional[int] = None, col_index_resultados: Optional[int] = None) -> Dict[str, Any]:
         """Calcula indicadores de rotación adaptándose dinámicamente al tipo de periodo."""
         self._trace_buffer.clear()
         self._current_periodicidad = periodicidad
@@ -1230,24 +1242,27 @@ class FinancialCalculator:
         tablas_balance = self._get_tables(balance_data)
         tablas_resultados = self._get_tables(resultados_data)
         usar_acumulado, dias_periodo = self._parse_periodicidad(periodicidad)
-        
+
+        idx_b = col_index_balance if col_index_balance is not None else col_index
+        idx_r = col_index_resultados if col_index_resultados is not None else col_index
+
         multiplicador = max(self._detect_scale(balance_data), self._detect_scale(resultados_data))
 
         # --- EXTRACCIÓN BÁSICA ---
-        cuentas_por_cobrar = self._find_value(tablas_balance, self.kw_cuentas_por_cobrar, take_last=usar_acumulado, col_index=0, skip_if_row_contains=["nacionales", "extranjeros"], concept_key="cuentas_por_cobrar") * multiplicador
-        inventario = self._find_value(tablas_balance, self.kw_inventario, take_last=usar_acumulado, col_index=0, concept_key="inventario") * multiplicador
-        activo_fijo_neto = self._find_value(tablas_balance, self.kw_activo_fijo, take_last=usar_acumulado, col_index=0, concept_key="activo_fijo") * multiplicador
-        activo_total = self._find_value(tablas_balance, self.kw_activo_total, take_last=usar_acumulado, col_index=0, concept_key="activo_total") * multiplicador
+        cuentas_por_cobrar = self._find_value(tablas_balance, self.kw_cuentas_por_cobrar, take_last=usar_acumulado, col_index=idx_b, skip_if_row_contains=["nacionales", "extranjeros"], concept_key="cuentas_por_cobrar") * multiplicador
+        inventario = self._find_value(tablas_balance, self.kw_inventario, take_last=usar_acumulado, col_index=idx_b, concept_key="inventario") * multiplicador
+        activo_fijo_neto = self._find_value(tablas_balance, self.kw_activo_fijo, take_last=usar_acumulado, col_index=idx_b, concept_key="activo_fijo") * multiplicador
+        activo_total = self._find_value(tablas_balance, self.kw_activo_total, take_last=usar_acumulado, col_index=idx_b, concept_key="activo_total") * multiplicador
 
         # Usamos nuestra variable dinámica 'usar_acumulado' en lugar del True hardcodeado
-        ventas_netas = self._find_value(tablas_resultados, self.kw_ventas_netas, take_last=usar_acumulado, col_index=col_index, concept_key="ventas_netas") * multiplicador
-        
-        if ventas_netas == 0:
-            ventas_netas = self._find_value(tablas_resultados, ["ingresos"], take_last=usar_acumulado, col_index=col_index) * multiplicador
+        ventas_netas = self._find_value(tablas_resultados, self.kw_ventas_netas, take_last=usar_acumulado, col_index=idx_r, concept_key="ventas_netas") * multiplicador
 
-        costo_directo = self._find_value(tablas_resultados, self.kw_costo_de_ventas, take_last=usar_acumulado, col_index=col_index, concept_key="costo_de_ventas") * multiplicador
-        compras = self._find_value(tablas_resultados, self.kw_compras, take_last=usar_acumulado, col_index=col_index) * multiplicador
-        devoluciones = self._find_value(tablas_resultados, self.kw_devoluciones_costo, take_last=usar_acumulado, col_index=col_index) * multiplicador
+        if ventas_netas == 0:
+            ventas_netas = self._find_value(tablas_resultados, ["ingresos"], take_last=usar_acumulado, col_index=idx_r) * multiplicador
+
+        costo_directo = self._find_value(tablas_resultados, self.kw_costo_de_ventas, take_last=usar_acumulado, col_index=idx_r, concept_key="costo_de_ventas") * multiplicador
+        compras = self._find_value(tablas_resultados, self.kw_compras, take_last=usar_acumulado, col_index=idx_r) * multiplicador
+        devoluciones = self._find_value(tablas_resultados, self.kw_devoluciones_costo, take_last=usar_acumulado, col_index=idx_r) * multiplicador
         
         costo_ventas_calculado = abs(costo_directo) + abs(compras) - abs(devoluciones)        
         if costo_ventas_calculado < 0: costo_ventas_calculado = 0
@@ -1331,28 +1346,30 @@ class FinancialCalculator:
             ],
         }
 
-    def calcular_estructura(self, balance_data: Dict[str, Any], periodicidad: str = "anual", col_index: int = 0, formato_perfil: str = "vertical_simple") -> Dict[str, Any]:
+    def calcular_estructura(self, balance_data: Dict[str, Any], periodicidad: str = "anual", col_index: int = 0, formato_perfil: str = "vertical_simple", col_index_balance: Optional[int] = None) -> Dict[str, Any]:
         """Calcula indicadores de estructura financiera basándose en el Balance General."""
         self._trace_buffer.clear()
         self._current_periodicidad = periodicidad
         self._current_formato_perfil = formato_perfil
         tablas_balance = self._get_tables(balance_data)
         usar_acumulado, _ = self._parse_periodicidad(periodicidad)
-        
+
+        idx_b = col_index_balance if col_index_balance is not None else col_index
+
         multiplicador = self._detect_scale(balance_data)
 
         # --- 1. EXTRACCIÓN BÁSICA ---
-        activo_total = self._find_value(tablas_balance, self.kw_activo_total, take_last=usar_acumulado, col_index=0, concept_key="activo_total") * multiplicador
-        activo_fijo = self._find_value(tablas_balance, self.kw_activo_fijo, take_last=usar_acumulado, col_index=0, concept_key="activo_fijo") * multiplicador
-        pasivo_total_doc = self._find_value(tablas_balance, self.kw_pasivo_total, take_last=usar_acumulado, col_index=0, skip_if_row_contains=["capital contable", "y capital", "y hacienda"], concept_key="pasivo_total") * multiplicador
-        capital_contable = self._find_value(tablas_balance, self.kw_capital, take_last=usar_acumulado, col_index=0, skip_if_row_contains=["pasivo y capital", "pasivo + capital", "pasivo y hacienda", "minoritario", "mayoritario", "minoritaria", "mayoritaria", "participación", "participacion"], concept_key="capital_contable") * multiplicador
-        pasivo_largo_plazo = self._find_value(tablas_balance, self.kw_pasivo_largo_plazo, take_last=usar_acumulado, col_index=0, skip_if_row_contains=["capital", "circulante", "corto", "deudores", "acreedores", "clientes", "activo"], concept_key="pasivo_largo_plazo") * multiplicador
-        pasivo_circulante = self._find_value(tablas_balance, self.kw_pasivo_circulante, take_last=usar_acumulado, col_index=0, concept_key="pasivo_circulante") * multiplicador
+        activo_total = self._find_value(tablas_balance, self.kw_activo_total, take_last=usar_acumulado, col_index=idx_b, concept_key="activo_total") * multiplicador
+        activo_fijo = self._find_value(tablas_balance, self.kw_activo_fijo, take_last=usar_acumulado, col_index=idx_b, concept_key="activo_fijo") * multiplicador
+        pasivo_total_doc = self._find_value(tablas_balance, self.kw_pasivo_total, take_last=usar_acumulado, col_index=idx_b, skip_if_row_contains=["capital contable", "y capital", "y hacienda"], concept_key="pasivo_total") * multiplicador
+        capital_contable = self._find_value(tablas_balance, self.kw_capital, take_last=usar_acumulado, col_index=idx_b, skip_if_row_contains=["pasivo y capital", "pasivo + capital", "pasivo y hacienda", "minoritario", "mayoritario", "minoritaria", "mayoritaria", "participación", "participacion"], concept_key="capital_contable") * multiplicador
+        pasivo_largo_plazo = self._find_value(tablas_balance, self.kw_pasivo_largo_plazo, take_last=usar_acumulado, col_index=idx_b, skip_if_row_contains=["capital", "circulante", "corto", "deudores", "acreedores", "clientes", "activo"], concept_key="pasivo_largo_plazo") * multiplicador
+        pasivo_circulante = self._find_value(tablas_balance, self.kw_pasivo_circulante, take_last=usar_acumulado, col_index=idx_b, concept_key="pasivo_circulante") * multiplicador
 
         # --- 2. LÓGICA INTELIGENTE PARA CAPITAL SOCIAL ---
-        capital_social_doc = self._find_value(tablas_balance, self.kw_capital_social, take_last=usar_acumulado, col_index=0, skip_if_row_contains=["pasivo y capital", "pasivo + capital", "pasivo y hacienda", "minoritario", "mayoritario", "contable"]) * multiplicador
-        capital_variable = self._find_value(tablas_balance, ["capital variable", "capital social variable"], take_last=usar_acumulado, col_index=0) * multiplicador
-        capital_fijo = self._find_value(tablas_balance, ["capital fijo", "capital social fijo"], take_last=usar_acumulado, col_index=0) * multiplicador
+        capital_social_doc = self._find_value(tablas_balance, self.kw_capital_social, take_last=usar_acumulado, col_index=idx_b, skip_if_row_contains=["pasivo y capital", "pasivo + capital", "pasivo y hacienda", "minoritario", "mayoritario", "contable"]) * multiplicador
+        capital_variable = self._find_value(tablas_balance, ["capital variable", "capital social variable"], take_last=usar_acumulado, col_index=idx_b) * multiplicador
+        capital_fijo = self._find_value(tablas_balance, ["capital fijo", "capital social fijo"], take_last=usar_acumulado, col_index=idx_b) * multiplicador
         
         suma_capitales = capital_fijo + capital_variable
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -432,6 +432,124 @@ COCACOLA_CFG = {
 }
 
 # ============================================================
+#  GRUPO BIMBO — trimestral Q1-2025
+#  Formato: corporativo BMV, balance vertical comparativo
+#  (col_actual | col_anterior | col_var%), millones de pesos.
+#  Nota: _detect_scale no detecta escala en balance sin text "millones"
+#  → Liquidez y Estructura usan multiplicador=1 (igual que en producción).
+# ============================================================
+
+BIMBO_BALANCE = {
+    "text_content": (
+        "Grupo Bimbo, S.A.B. de C.V.\n"
+        "Estado de Situación Financiera Consolidado\n"
+        "31 de marzo de 2025"
+    ),
+    "tables_data": [
+        _cells(
+            # col0=concepto, col1=Q1-2025, col2=Q1-2024, col3=var%
+            ("Activo circulante",                   "74,656",  "67,180",  "11.1"),
+            ("Inventarios",                         "17,763",  "18,832",  "(5.7)"),
+            ("Clientes y otras cuentas por cobrar", "27,988",  "26,631",  "5.1"),
+            ("Propiedad, planta y equipo",          "158,326", "155,376", "1.9"),
+            ("Activo total",                        "429,186", "416,804", "3.0"),
+            ("Pasivo circulante",                   "82,589",  "85,155",  "(3.0)"),
+            ("Pasivo total",                        "299,907", "289,107", "3.7"),
+            # Capital contable total aparece ANTES que el mayoritario en el
+            # documento → reversed search encuentra mayoritario primero.
+            # Rentabilidad (sin skip "mayoritario") toma 127,723.
+            # Estructura (con skip "mayoritario") toma 129,279.
+            ("Capital contable",                    "129,279", "127,698", "1.2"),
+            ("Capital contable mayoritario",        "127,723", "125,944", "1.4"),
+        )
+    ],
+}
+
+BIMBO_RESULTADOS = {
+    "text_content": (
+        "Grupo Bimbo, S.A.B. de C.V.\n"
+        "Estado de Resultados Consolidado\n"
+        "Millones de pesos\n"
+        "Primer trimestre terminado el 31 de marzo de 2025"
+    ),
+    "tables_data": [
+        _cells(
+            # col0=concepto, col1=Q1-2025, col2=Q1-2024, col3=var%
+            ("Ventas netas",                                "103,726", "93,641",  "10.8"),
+            ("Costo de ventas",                            "49,262",  "44,940",  "9.6"),
+            ("Gastos de operación",                        "47,976",  "41,826",  "14.7"),
+            ("Utilidad (Pérdida) de Operación",            "6,748",   "6,875",   "(1.8)"),
+            ("Resultado Integral de Financiamiento",       "3,256",   "2,773",   "17.4"),
+            ("Impuestos a la utilidad",                    "1,328",   "1,456",   "(8.8)"),
+            ("Utilidad (Pérdida) de Operaciones Continuas","2,214",   "2,757",   "(19.7)"),
+        )
+    ],
+}
+
+BIMBO_CFG = {
+    "balance":      BIMBO_BALANCE,
+    "resultados":   BIMBO_RESULTADOS,
+    "periodicidad": "trimestral",
+    "col_index":    0,
+}
+
+# ============================================================
+#  FEMSA — trimestral Q1-2025
+#  Formato: corporativo BMV, balance y ER comparativos
+#  con columnas: actual | %actual | anterior | %ant | var | var%
+#  Millones de pesos (detectado en balance → multiplicador=1,000,000 en todos los módulos).
+# ============================================================
+
+FEMSA_BALANCE = {
+    "text_content": (
+        "FOMENTO ECONÓMICO MEXICANO, S.A.B. de C.V.\n"
+        "Estado de Situación Financiera Consolidado\n"
+        "Millones de pesos\n"
+        "31 de marzo de 2025"
+    ),
+    "tables_data": [
+        _cells(
+            # col0=concepto, col1=Q1-2025, col2=Q1-2024, col3=var%
+            ("Total activo circulante",          "333,560", "342,311", "(2.6)"),
+            ("Inventarios",                      "66,548",  "67,464",  "(1.4)"),
+            ("Cuentas por cobrar",               "41,818",  "43,192",  "(3.2)"),
+            ("Propiedad, planta y equipo, neto", "181,957", "177,511", "2.5"),
+            ("Total activos",                    "855,883", "851,536", "0.5"),
+            ("Total pasivo circulante",          "203,393", "202,930", "0.2"),
+            ("Total pasivos",                    "464,107", "470,405", "(1.3)"),
+            ("Total capital contable",           "391,776", "381,131", "2.8"),
+        )
+    ],
+}
+
+FEMSA_RESULTADOS = {
+    "text_content": (
+        "FOMENTO ECONÓMICO MEXICANO, S.A.B. de C.V.\n"
+        "Estado de Resultados Consolidado\n"
+        "Millones de pesos\n"
+        "Primer trimestre terminado el 31 de marzo de 2025"
+    ),
+    "tables_data": [
+        _cells(
+            # col0=concepto, col1=Q1-2025, col2=%25, col3=Q1-2024, col4=%24, col5=var, col6=var%
+            ("Ingresos totales",               "195,820", "100.0", "176,334", "100.0", "11.1", "5.6"),
+            ("Costo de ventas",                "116,902", "59.7",  "108,157", "61.3",  "8.1"),
+            ("Utilidad de operación",          "13,565",  "6.9",   "12,936",  "7.3",   "4.9",  "1.7"),
+            ("Gastos de financiamiento, neto", "1,413",   "3,377", "(58.2)"),
+            ("ISR",                            "4,781",   "3,356", "42.5"),
+            ("(Pérdida) Utilidad neta consolidada", "8,943", "5,794", "54.3"),
+        )
+    ],
+}
+
+FEMSA_CFG = {
+    "balance":      FEMSA_BALANCE,
+    "resultados":   FEMSA_RESULTADOS,
+    "periodicidad": "trimestral",
+    "col_index":    0,
+}
+
+# ============================================================
 #  Mapa global de casos de prueba
 # ============================================================
 ALL_CASES = {
@@ -441,6 +559,8 @@ ALL_CASES = {
     "taas_ene":        TAAS_ENE_CFG,
     "taas_mar":        TAAS_MAR_CFG,
     "cocacola":        COCACOLA_CFG,
+    "bimbo":           BIMBO_CFG,
+    "femsa":           FEMSA_CFG,
 }
 
 GOLDEN_DIR = os.path.join(os.path.dirname(__file__), "golden")

--- a/backend/tests/golden/bimbo_endeudamiento.json
+++ b/backend/tests/golden/bimbo_endeudamiento.json
@@ -1,0 +1,65 @@
+{
+  "datos_crudos": {
+    "pasivo_total": 299907000000.0,
+    "activo_total": 429186000000.0,
+    "capital_social": 127723000000.0,
+    "utilidad_operacion": 6748000000.0,
+    "intereses": 3256000000.0,
+    "multiplicador": 1000000,
+    "_extraction_trace": {
+      "activo_total": {
+        "method": "keyword",
+        "matched_term": "activo total",
+        "row_snippet": "activo total 429,186 416,804 3.0"
+      },
+      "capital_contable": {
+        "method": "keyword",
+        "matched_term": "capital contable",
+        "row_snippet": "capital contable mayoritario 127,723 125,944 1.4"
+      },
+      "pasivo_total": {
+        "method": "keyword",
+        "matched_term": "pasivo total",
+        "row_snippet": "pasivo total 299,907 289,107 3.7"
+      },
+      "utilidad_operacion": {
+        "method": "keyword",
+        "matched_term": "utilidad (pérdida) de operación",
+        "row_snippet": "utilidad (pérdida) de operación 6,748 6,875 (1.8)"
+      },
+      "gastos_financieros": {
+        "method": "keyword",
+        "matched_term": "resultado integral de financiamiento",
+        "row_snippet": "resultado integral de financiamiento 3,256 2,773 17.4"
+      },
+      "utilidad_neta": {
+        "method": "keyword",
+        "matched_term": "operaciones continuas",
+        "row_snippet": "utilidad (pérdida) de operaciones continuas 2,214 2,757 (19.7)"
+      },
+      "impuestos": {
+        "method": "keyword",
+        "matched_term": "impuestos a la utilidad",
+        "row_snippet": "impuestos a la utilidad 1,328 1,456 (8.8)"
+      }
+    },
+    "_warnings": null
+  },
+  "kpis": [
+    {
+      "label": "Apalancamiento",
+      "value": "0.70",
+      "status": "warn"
+    },
+    {
+      "label": "Razón de Cobertura de Intereses",
+      "value": "2.07",
+      "status": "ok"
+    },
+    {
+      "label": "Estabilidad Financiera",
+      "value": "2.35",
+      "status": "danger"
+    }
+  ]
+}

--- a/backend/tests/golden/bimbo_endeudamiento.json
+++ b/backend/tests/golden/bimbo_endeudamiento.json
@@ -43,7 +43,37 @@
         "row_snippet": "impuestos a la utilidad 1,328 1,456 (8.8)"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "pasivo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Pasivo"
+      },
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "capital_contable": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital Contable"
+      },
+      "utilidad_operacion": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Utilidad de operación"
+      },
+      "gastos_financieros": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Gastos financieros (Intereses a cargo)"
+      },
+      "utilidad_neta": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Utilidad / pérdida del ejercicio"
+      },
+      "impuestos": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Impuestos a la utilidad"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/bimbo_estructura.json
+++ b/backend/tests/golden/bimbo_estructura.json
@@ -1,42 +1,42 @@
 {
   "datos_crudos": {
-    "activo_total": 333116000000.0,
-    "pasivo_total": 186246000000.0,
+    "activo_total": 429186.0,
+    "pasivo_total": 299907.0,
     "capital_social": 0.0,
-    "capital_contable": 146870000000.0,
-    "activo_fijo": 111725000000.0,
-    "pasivo_largo_plazo": 107901000000.0,
-    "multiplicador": 1000000,
+    "capital_contable": 129279.0,
+    "activo_fijo": 158326.0,
+    "pasivo_largo_plazo": 217318.0,
+    "multiplicador": 1,
     "_extraction_trace": {
       "activo_total": {
         "method": "keyword",
-        "matched_term": "total activos",
-        "row_snippet": "total activos 333,116 total capital 146,870"
+        "matched_term": "activo total",
+        "row_snippet": "activo total 429,186 416,804 3.0"
       },
       "activo_fijo": {
         "method": "keyword",
         "matched_term": "propiedad, planta y equipo",
-        "row_snippet": "total propiedad, planta y equipo, neto 111,725 otros pasivos de largo plazo 22,811"
+        "row_snippet": "propiedad, planta y equipo 158,326 155,376 1.9"
       },
       "pasivo_total": {
         "method": "keyword",
-        "matched_term": "total pasivo",
-        "row_snippet": "activos por derechos de uso 3,461 total pasivo 186,246"
+        "matched_term": "pasivo total",
+        "row_snippet": "pasivo total 299,907 289,107 3.7"
       },
       "capital_contable": {
         "method": "keyword",
-        "matched_term": "total capital",
-        "row_snippet": "total activos 333,116 total capital 146,870"
+        "matched_term": "capital contable",
+        "row_snippet": "capital contable 129,279 127,698 1.2"
       },
       "pasivo_largo_plazo": {
         "method": "math_rescue",
         "formula": "pasivo_total - pasivo_circulante",
-        "value": 107901000000.0
+        "value": 217318.0
       },
       "pasivo_circulante": {
         "method": "keyword",
         "matched_term": "pasivo circulante",
-        "row_snippet": "total activos circulantes 86,141 pasivo circulante 78,345"
+        "row_snippet": "pasivo circulante 82,589 85,155 (3.0)"
       }
     },
     "_warnings": null
@@ -44,13 +44,13 @@
   "kpis": [
     {
       "label": "Solvencia General",
-      "value": "1.79",
+      "value": "1.43",
       "status": "ok"
     },
     {
       "label": "Seguridad a largo plazo",
-      "value": "1.04",
-      "status": "ok"
+      "value": "0.73",
+      "status": "warn"
     },
     {
       "label": "Inmovilización de Cap. Social",
@@ -59,8 +59,8 @@
     },
     {
       "label": "Inmovilización de Cap. Contable",
-      "value": "0.76",
-      "status": "ok"
+      "value": "1.22",
+      "status": "warn"
     }
   ]
 }

--- a/backend/tests/golden/bimbo_estructura.json
+++ b/backend/tests/golden/bimbo_estructura.json
@@ -39,7 +39,37 @@
         "row_snippet": "pasivo circulante 82,589 85,155 (3.0)"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "pasivo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Pasivo"
+      },
+      "capital_social": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital social"
+      },
+      "capital_contable": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital Contable"
+      },
+      "activo_fijo": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Propiedades, planta y equipo"
+      },
+      "pasivo_largo_plazo": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Pasivo a largo plazo"
+      },
+      "pasivo_circulante": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Pasivo a corto plazo"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/bimbo_liquidez.json
+++ b/backend/tests/golden/bimbo_liquidez.json
@@ -21,7 +21,21 @@
         "row_snippet": "inventarios 17,763 18,832 (5.7)"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "activo_circulante": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Activo a corto plazo (circulante)"
+      },
+      "pasivo_circulante": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Pasivo a corto plazo"
+      },
+      "inventario": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Inventarios"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/bimbo_liquidez.json
+++ b/backend/tests/golden/bimbo_liquidez.json
@@ -1,22 +1,24 @@
 {
   "datos_crudos": {
-    "activo_circulante": 3214133.9,
-    "pasivo_circulante": 1072748.57,
-    "inventario": 0.0,
+    "activo_circulante": 74656.0,
+    "pasivo_circulante": 82589.0,
+    "inventario": 17763.0,
     "multiplicador": 1,
     "_extraction_trace": {
       "activo_circulante": {
         "method": "keyword",
         "matched_term": "activo circulante",
-        "row_snippet": "activo circulante 3,214,133.90 resul. del ejercicio 3,784,287.01"
+        "row_snippet": "activo circulante 74,656 67,180 11.1"
       },
       "pasivo_circulante": {
         "method": "keyword",
         "matched_term": "pasivo circulante",
-        "row_snippet": "iva retenido 6,200.47 pasivo circulante -1,072,748.57"
+        "row_snippet": "pasivo circulante 82,589 85,155 (3.0)"
       },
       "inventario": {
-        "method": "not_found"
+        "method": "keyword",
+        "matched_term": "inventarios",
+        "row_snippet": "inventarios 17,763 18,832 (5.7)"
       }
     },
     "_warnings": null
@@ -24,18 +26,18 @@
   "kpis": [
     {
       "label": "Razón de Liquidez",
-      "value": "3.00",
-      "status": "ok"
+      "value": "0.90",
+      "status": "warn"
     },
     {
       "label": "Prueba del Ácido",
-      "value": "3.00",
-      "status": "ok"
+      "value": "0.69",
+      "status": "warn"
     },
     {
       "label": "Capital de Trabajo",
-      "value": "$2,141,385.33",
-      "status": "ok"
+      "value": "$-7,933.00",
+      "status": "danger"
     }
   ]
 }

--- a/backend/tests/golden/bimbo_rentabilidad.json
+++ b/backend/tests/golden/bimbo_rentabilidad.json
@@ -27,7 +27,25 @@
         "row_snippet": "capital contable mayoritario 127,723 125,944 1.4"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "utilidad_neta": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Utilidad / pérdida del ejercicio"
+      },
+      "ventas_netas": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Ventas o Ingresos netos"
+      },
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "capital_contable": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital Contable"
+      }
+    }
   },
   "kpis": [
     {
@@ -38,12 +56,14 @@
     {
       "label": "Rendimiento sobre Activos Totales (RAT)",
       "value": "0.52%",
-      "status": "warn"
+      "status": "warn",
+      "nota_periodo": "valor trimestral"
     },
     {
       "label": "Rendimiento sobre el Patrimonio",
       "value": "1.73%",
-      "status": "warn"
+      "status": "warn",
+      "nota_periodo": "valor trimestral"
     }
   ]
 }

--- a/backend/tests/golden/bimbo_rentabilidad.json
+++ b/backend/tests/golden/bimbo_rentabilidad.json
@@ -1,0 +1,49 @@
+{
+  "datos_crudos": {
+    "utilidad_neta": 2214000000.0,
+    "ventas_netas": 103726000000.0,
+    "activo_total": 429186000000.0,
+    "capital_contable": 127723000000.0,
+    "multiplicador": 1000000,
+    "_extraction_trace": {
+      "ventas_netas": {
+        "method": "keyword",
+        "matched_term": "ventas netas",
+        "row_snippet": "ventas netas 103,726 93,641 10.8"
+      },
+      "utilidad_neta": {
+        "method": "keyword",
+        "matched_term": "operaciones continuas",
+        "row_snippet": "utilidad (pérdida) de operaciones continuas 2,214 2,757 (19.7)"
+      },
+      "activo_total": {
+        "method": "keyword",
+        "matched_term": "activo total",
+        "row_snippet": "activo total 429,186 416,804 3.0"
+      },
+      "capital_contable": {
+        "method": "keyword",
+        "matched_term": "capital contable",
+        "row_snippet": "capital contable mayoritario 127,723 125,944 1.4"
+      }
+    },
+    "_warnings": null
+  },
+  "kpis": [
+    {
+      "label": "Margen de Rentabilidad",
+      "value": "2.13%",
+      "status": "warn"
+    },
+    {
+      "label": "Rendimiento sobre Activos Totales (RAT)",
+      "value": "0.52%",
+      "status": "warn"
+    },
+    {
+      "label": "Rendimiento sobre el Patrimonio",
+      "value": "1.73%",
+      "status": "warn"
+    }
+  ]
+}

--- a/backend/tests/golden/bimbo_rotacion.json
+++ b/backend/tests/golden/bimbo_rotacion.json
@@ -1,43 +1,43 @@
 {
   "datos_crudos": {
-    "cuentas_por_cobrar": 380000.0,
-    "inventario": 900000.0,
-    "activo_fijo_neto": 2100000.0,
-    "activo_total": 4455000.0,
-    "ventas_netas": 3500000.0,
-    "costo_ventas": 1900000.0,
-    "dias_calculo": 360,
-    "multiplicador": 1,
+    "cuentas_por_cobrar": 27988000000.0,
+    "inventario": 17763000000.0,
+    "activo_fijo_neto": 158326000000.0,
+    "activo_total": 429186000000.0,
+    "ventas_netas": 103726000000.0,
+    "costo_ventas": 49262000000.0,
+    "dias_calculo": 90,
+    "multiplicador": 1000000,
     "_extraction_trace": {
       "cuentas_por_cobrar": {
         "method": "keyword",
-        "matched_term": "clientes",
-        "row_snippet": "clientes 380,000 ptu por pagar 32,000"
+        "matched_term": "cuentas por cobrar",
+        "row_snippet": "clientes y otras cuentas por cobrar 27,988 26,631 5.1"
       },
       "inventario": {
         "method": "keyword",
         "matched_term": "inventarios",
-        "row_snippet": "inventarios 900,000 isr por pagar 96,000"
+        "row_snippet": "inventarios 17,763 18,832 (5.7)"
       },
       "activo_fijo": {
         "method": "keyword",
-        "matched_term": "total activo no circulante",
-        "row_snippet": "total activo no circulante 2,100,000 utilid. ejercicios 377,000"
+        "matched_term": "propiedad, planta y equipo",
+        "row_snippet": "propiedad, planta y equipo 158,326 155,376 1.9"
       },
       "activo_total": {
         "method": "keyword",
-        "matched_term": "total activo",
-        "row_snippet": "total activo 4,455,000 tot. pas+cap 4,455,000"
+        "matched_term": "activo total",
+        "row_snippet": "activo total 429,186 416,804 3.0"
       },
       "ventas_netas": {
         "method": "keyword",
         "matched_term": "ventas netas",
-        "row_snippet": "ventas netas 3,500,000"
+        "row_snippet": "ventas netas 103,726 93,641 10.8"
       },
       "costo_de_ventas": {
         "method": "keyword",
         "matched_term": "costo de ventas",
-        "row_snippet": "(-) costo de ventas (1,900,000)"
+        "row_snippet": "costo de ventas 49,262 44,940 9.6"
       }
     },
     "_warnings": null
@@ -45,27 +45,27 @@
   "kpis": [
     {
       "label": "Rotación de la Cartera",
-      "value": "9.21",
+      "value": "3.71",
       "status": "ok"
     },
     {
       "label": "Periodo Promedio de Recaudo",
-      "value": "39 días",
+      "value": "24 días",
       "status": "ok"
     },
     {
       "label": "Rotación de Inventarios",
-      "value": "2.11",
+      "value": "2.77",
       "status": "ok"
     },
     {
       "label": "Rotación de Activos Fijos",
-      "value": "1.67",
+      "value": "0.66",
       "status": "ok"
     },
     {
       "label": "Rotación de Activos Totales",
-      "value": "0.79",
+      "value": "0.24",
       "status": "warn"
     }
   ]

--- a/backend/tests/golden/bimbo_rotacion.json
+++ b/backend/tests/golden/bimbo_rotacion.json
@@ -12,7 +12,9 @@
       "cuentas_por_cobrar": {
         "method": "keyword",
         "matched_term": "cuentas por cobrar",
-        "row_snippet": "clientes y otras cuentas por cobrar 27,988 26,631 5.1"
+        "row_snippet": "clientes y otras cuentas por cobrar 27,988 26,631 5.1",
+        "composed": true,
+        "composed_marker": "y otras cuentas por cobrar"
       },
       "inventario": {
         "method": "keyword",
@@ -40,13 +42,42 @@
         "row_snippet": "costo de ventas 49,262 44,940 9.6"
       }
     },
-    "_warnings": null
+    "_warnings": [
+      "cuentas_por_cobrar: valor extraído de una cuenta compuesta (fila contiene 'y otras cuentas por cobrar'). Incluye sub-cuentas que no pueden separarse sin información adicional."
+    ],
+    "fuentes": {
+      "cuentas_por_cobrar": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Cuentas por cobrar a clientes"
+      },
+      "inventario": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Inventarios"
+      },
+      "activo_fijo": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Propiedades, planta y equipo"
+      },
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "ventas_netas": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Ventas o Ingresos netos"
+      },
+      "costo_de_ventas": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Costo de ventas"
+      }
+    }
   },
   "kpis": [
     {
       "label": "Rotación de la Cartera",
       "value": "3.71",
-      "status": "ok"
+      "status": "ok",
+      "nota_periodo": "valor trimestral"
     },
     {
       "label": "Periodo Promedio de Recaudo",
@@ -56,17 +87,20 @@
     {
       "label": "Rotación de Inventarios",
       "value": "2.77",
-      "status": "ok"
+      "status": "ok",
+      "nota_periodo": "valor trimestral"
     },
     {
       "label": "Rotación de Activos Fijos",
       "value": "0.66",
-      "status": "ok"
+      "status": "ok",
+      "nota_periodo": "valor trimestral"
     },
     {
       "label": "Rotación de Activos Totales",
       "value": "0.24",
-      "status": "warn"
+      "status": "warn",
+      "nota_periodo": "valor trimestral"
     }
   ]
 }

--- a/backend/tests/golden/cocacola_endeudamiento.json
+++ b/backend/tests/golden/cocacola_endeudamiento.json
@@ -41,7 +41,37 @@
         "method": "not_found"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "pasivo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Pasivo"
+      },
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "capital_contable": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital Contable"
+      },
+      "utilidad_operacion": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Utilidad de operación"
+      },
+      "gastos_financieros": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Gastos financieros (Intereses a cargo)"
+      },
+      "utilidad_neta": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Utilidad / pérdida del ejercicio"
+      },
+      "impuestos": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Impuestos a la utilidad"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/cocacola_endeudamiento.json
+++ b/backend/tests/golden/cocacola_endeudamiento.json
@@ -5,7 +5,43 @@
     "capital_social": 146870000000.0,
     "utilidad_operacion": 9032000000.0,
     "intereses": 1752000000.0,
-    "multiplicador": 1000000
+    "multiplicador": 1000000,
+    "_extraction_trace": {
+      "activo_total": {
+        "method": "keyword",
+        "matched_term": "total activos",
+        "row_snippet": "total activos 333,116 total capital 146,870"
+      },
+      "capital_contable": {
+        "method": "keyword",
+        "matched_term": "total capital",
+        "row_snippet": "total activos 333,116 total capital 146,870"
+      },
+      "pasivo_total": {
+        "method": "keyword",
+        "matched_term": "total pasivo",
+        "row_snippet": "activos por derechos de uso 3,461 total pasivo 186,246"
+      },
+      "utilidad_operacion": {
+        "method": "keyword",
+        "matched_term": "utilidad de operación",
+        "row_snippet": "utilidad de operación 9,032 12.7% 9,248 13.2%"
+      },
+      "gastos_financieros": {
+        "method": "keyword",
+        "matched_term": "resultado integral de financiamiento",
+        "row_snippet": "resultado integral de financiamiento 1,752 1,126"
+      },
+      "utilidad_neta": {
+        "method": "keyword",
+        "matched_term": "utilidad neta",
+        "row_snippet": "utilidad neta consolidada 4,735 5,492"
+      },
+      "impuestos": {
+        "method": "not_found"
+      }
+    },
+    "_warnings": null
   },
   "kpis": [
     {

--- a/backend/tests/golden/cocacola_estructura.json
+++ b/backend/tests/golden/cocacola_estructura.json
@@ -39,7 +39,37 @@
         "row_snippet": "total activos circulantes 86,141 pasivo circulante 78,345"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "pasivo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Pasivo"
+      },
+      "capital_social": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital social"
+      },
+      "capital_contable": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital Contable"
+      },
+      "activo_fijo": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Propiedades, planta y equipo"
+      },
+      "pasivo_largo_plazo": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Pasivo a largo plazo"
+      },
+      "pasivo_circulante": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Pasivo a corto plazo"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/cocacola_liquidez.json
+++ b/backend/tests/golden/cocacola_liquidez.json
@@ -3,7 +3,25 @@
     "activo_circulante": 86141000000.0,
     "pasivo_circulante": 78345000000.0,
     "inventario": 14814000000.0,
-    "multiplicador": 1000000
+    "multiplicador": 1000000,
+    "_extraction_trace": {
+      "activo_circulante": {
+        "method": "keyword",
+        "matched_term": "total activos circulantes",
+        "row_snippet": "total activos circulantes 86,141 pasivo circulante 78,345"
+      },
+      "pasivo_circulante": {
+        "method": "keyword",
+        "matched_term": "pasivo circulante",
+        "row_snippet": "total activos circulantes 86,141 pasivo circulante 78,345"
+      },
+      "inventario": {
+        "method": "keyword",
+        "matched_term": "inventarios",
+        "row_snippet": "inventarios 14,814 vencimiento cp pasivo arrendamiento 952"
+      }
+    },
+    "_warnings": null
   },
   "kpis": [
     {

--- a/backend/tests/golden/cocacola_liquidez.json
+++ b/backend/tests/golden/cocacola_liquidez.json
@@ -21,7 +21,21 @@
         "row_snippet": "inventarios 14,814 vencimiento cp pasivo arrendamiento 952"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "activo_circulante": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Activo a corto plazo (circulante)"
+      },
+      "pasivo_circulante": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Pasivo a corto plazo"
+      },
+      "inventario": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Inventarios"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/cocacola_rentabilidad.json
+++ b/backend/tests/golden/cocacola_rentabilidad.json
@@ -27,7 +27,25 @@
         "row_snippet": "total activos 333,116 total capital 146,870"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "utilidad_neta": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Utilidad / pérdida del ejercicio"
+      },
+      "ventas_netas": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Ventas o Ingresos netos"
+      },
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "capital_contable": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital Contable"
+      }
+    }
   },
   "kpis": [
     {
@@ -38,12 +56,14 @@
     {
       "label": "Rendimiento sobre Activos Totales (RAT)",
       "value": "1.42%",
-      "status": "ok"
+      "status": "ok",
+      "nota_periodo": "valor trimestral"
     },
     {
       "label": "Rendimiento sobre el Patrimonio",
       "value": "3.22%",
-      "status": "ok"
+      "status": "ok",
+      "nota_periodo": "valor trimestral"
     }
   ]
 }

--- a/backend/tests/golden/cocacola_rotacion.json
+++ b/backend/tests/golden/cocacola_rotacion.json
@@ -40,13 +40,40 @@
         "row_snippet": "costo de ventas 37,670 53.1% 38,324 54.6%"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "cuentas_por_cobrar": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Cuentas por cobrar a clientes"
+      },
+      "inventario": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Inventarios"
+      },
+      "activo_fijo": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Propiedades, planta y equipo"
+      },
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "ventas_netas": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Ventas o Ingresos netos"
+      },
+      "costo_de_ventas": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Costo de ventas"
+      }
+    }
   },
   "kpis": [
     {
       "label": "Rotación de la Cartera",
       "value": "4.00",
-      "status": "ok"
+      "status": "ok",
+      "nota_periodo": "valor trimestral"
     },
     {
       "label": "Periodo Promedio de Recaudo",
@@ -56,17 +83,20 @@
     {
       "label": "Rotación de Inventarios",
       "value": "2.54",
-      "status": "ok"
+      "status": "ok",
+      "nota_periodo": "valor trimestral"
     },
     {
       "label": "Rotación de Activos Fijos",
       "value": "0.63",
-      "status": "ok"
+      "status": "ok",
+      "nota_periodo": "valor trimestral"
     },
     {
       "label": "Rotación de Activos Totales",
       "value": "0.21",
-      "status": "warn"
+      "status": "warn",
+      "nota_periodo": "valor trimestral"
     }
   ]
 }

--- a/backend/tests/golden/ecogreen_endeudamiento.json
+++ b/backend/tests/golden/ecogreen_endeudamiento.json
@@ -5,7 +5,45 @@
     "capital_social": 2727000.0,
     "utilidad_operacion": 420000.0,
     "intereses": 100000.0,
-    "multiplicador": 1
+    "multiplicador": 1,
+    "_extraction_trace": {
+      "activo_total": {
+        "method": "keyword",
+        "matched_term": "total activo",
+        "row_snippet": "total activo 4,455,000 tot. pas+cap 4,455,000"
+      },
+      "capital_contable": {
+        "method": "keyword",
+        "matched_term": "total capital contable",
+        "row_snippet": "total capital contable 2,727,000"
+      },
+      "pasivo_total": {
+        "method": "keyword",
+        "matched_term": "total pasivo",
+        "row_snippet": "no circulante total pasivo 1,728,000"
+      },
+      "utilidad_operacion": {
+        "method": "keyword",
+        "matched_term": "utilidad de operación",
+        "row_snippet": "utilidad de operación 420,000"
+      },
+      "gastos_financieros": {
+        "method": "keyword",
+        "matched_term": "gastos financieros",
+        "row_snippet": "(-) gastos financieros (100,000)"
+      },
+      "utilidad_neta": {
+        "method": "keyword",
+        "matched_term": "utilidad neta",
+        "row_snippet": "utilidad neta 192,000"
+      },
+      "impuestos": {
+        "method": "keyword",
+        "matched_term": "isr",
+        "row_snippet": "(-) isr (30%) (96,000)"
+      }
+    },
+    "_warnings": null
   },
   "kpis": [
     {

--- a/backend/tests/golden/ecogreen_endeudamiento.json
+++ b/backend/tests/golden/ecogreen_endeudamiento.json
@@ -43,7 +43,37 @@
         "row_snippet": "(-) isr (30%) (96,000)"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "pasivo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Pasivo"
+      },
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "capital_contable": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital Contable"
+      },
+      "utilidad_operacion": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Utilidad de operación"
+      },
+      "gastos_financieros": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Gastos financieros (Intereses a cargo)"
+      },
+      "utilidad_neta": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Utilidad / pérdida del ejercicio"
+      },
+      "impuestos": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Impuestos a la utilidad"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/ecogreen_estructura.json
+++ b/backend/tests/golden/ecogreen_estructura.json
@@ -39,7 +39,37 @@
         "row_snippet": "seguros anticipados 25,000 total pasivo a corto plazo 528,000"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "pasivo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Pasivo"
+      },
+      "capital_social": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital social"
+      },
+      "capital_contable": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital Contable"
+      },
+      "activo_fijo": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Propiedades, planta y equipo"
+      },
+      "pasivo_largo_plazo": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Pasivo a largo plazo"
+      },
+      "pasivo_circulante": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Pasivo a corto plazo"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/ecogreen_estructura.json
+++ b/backend/tests/golden/ecogreen_estructura.json
@@ -6,7 +6,40 @@
     "capital_contable": 2727000.0,
     "activo_fijo": 2100000.0,
     "pasivo_largo_plazo": 1200000.0,
-    "multiplicador": 1
+    "multiplicador": 1,
+    "_extraction_trace": {
+      "activo_total": {
+        "method": "keyword",
+        "matched_term": "total activo",
+        "row_snippet": "total activo 4,455,000 tot. pas+cap 4,455,000"
+      },
+      "activo_fijo": {
+        "method": "keyword",
+        "matched_term": "total activo no circulante",
+        "row_snippet": "total activo no circulante 2,100,000 utilid. ejercicios 377,000"
+      },
+      "pasivo_total": {
+        "method": "keyword",
+        "matched_term": "total pasivo",
+        "row_snippet": "no circulante total pasivo 1,728,000"
+      },
+      "capital_contable": {
+        "method": "keyword",
+        "matched_term": "total capital contable",
+        "row_snippet": "total capital contable 2,727,000"
+      },
+      "pasivo_largo_plazo": {
+        "method": "math_rescue",
+        "formula": "pasivo_total - pasivo_circulante",
+        "value": 1200000.0
+      },
+      "pasivo_circulante": {
+        "method": "keyword",
+        "matched_term": "pasivo a corto plazo",
+        "row_snippet": "seguros anticipados 25,000 total pasivo a corto plazo 528,000"
+      }
+    },
+    "_warnings": null
   },
   "kpis": [
     {

--- a/backend/tests/golden/ecogreen_liquidez.json
+++ b/backend/tests/golden/ecogreen_liquidez.json
@@ -21,7 +21,21 @@
         "row_snippet": "inventarios 900,000 isr por pagar 96,000"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "activo_circulante": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Activo a corto plazo (circulante)"
+      },
+      "pasivo_circulante": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Pasivo a corto plazo"
+      },
+      "inventario": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Inventarios"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/ecogreen_rentabilidad.json
+++ b/backend/tests/golden/ecogreen_rentabilidad.json
@@ -27,7 +27,25 @@
         "row_snippet": "total capital contable 2,727,000"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "utilidad_neta": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Utilidad / pérdida del ejercicio"
+      },
+      "ventas_netas": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Ventas o Ingresos netos"
+      },
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "capital_contable": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital Contable"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/ecogreen_rentabilidad.json
+++ b/backend/tests/golden/ecogreen_rentabilidad.json
@@ -4,7 +4,30 @@
     "ventas_netas": 3500000.0,
     "activo_total": 4455000.0,
     "capital_contable": 2727000.0,
-    "multiplicador": 1
+    "multiplicador": 1,
+    "_extraction_trace": {
+      "ventas_netas": {
+        "method": "keyword",
+        "matched_term": "ventas netas",
+        "row_snippet": "ventas netas 3,500,000"
+      },
+      "utilidad_neta": {
+        "method": "keyword",
+        "matched_term": "utilidad neta",
+        "row_snippet": "utilidad neta 192,000"
+      },
+      "activo_total": {
+        "method": "keyword",
+        "matched_term": "total activo",
+        "row_snippet": "total activo 4,455,000 tot. pas+cap 4,455,000"
+      },
+      "capital_contable": {
+        "method": "keyword",
+        "matched_term": "total capital contable",
+        "row_snippet": "total capital contable 2,727,000"
+      }
+    },
+    "_warnings": null
   },
   "kpis": [
     {

--- a/backend/tests/golden/ecogreen_rotacion.json
+++ b/backend/tests/golden/ecogreen_rotacion.json
@@ -40,7 +40,33 @@
         "row_snippet": "(-) costo de ventas (1,900,000)"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "cuentas_por_cobrar": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Cuentas por cobrar a clientes"
+      },
+      "inventario": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Inventarios"
+      },
+      "activo_fijo": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Propiedades, planta y equipo"
+      },
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "ventas_netas": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Ventas o Ingresos netos"
+      },
+      "costo_de_ventas": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Costo de ventas"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/femsa_endeudamiento.json
+++ b/backend/tests/golden/femsa_endeudamiento.json
@@ -43,7 +43,37 @@
         "row_snippet": "isr 4,781 3,356 42.5"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "pasivo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Pasivo"
+      },
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "capital_contable": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital Contable"
+      },
+      "utilidad_operacion": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Utilidad de operación"
+      },
+      "gastos_financieros": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Gastos financieros (Intereses a cargo)"
+      },
+      "utilidad_neta": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Utilidad / pérdida del ejercicio"
+      },
+      "impuestos": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Impuestos a la utilidad"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/femsa_endeudamiento.json
+++ b/backend/tests/golden/femsa_endeudamiento.json
@@ -1,0 +1,65 @@
+{
+  "datos_crudos": {
+    "pasivo_total": 464107000000.0,
+    "activo_total": 855883000000.0,
+    "capital_social": 391776000000.0,
+    "utilidad_operacion": 13565000000.0,
+    "intereses": 1413000000.0,
+    "multiplicador": 1000000,
+    "_extraction_trace": {
+      "activo_total": {
+        "method": "keyword",
+        "matched_term": "total activos",
+        "row_snippet": "total activos 855,883 851,536 0.5"
+      },
+      "capital_contable": {
+        "method": "keyword",
+        "matched_term": "total capital contable",
+        "row_snippet": "total capital contable 391,776 381,131 2.8"
+      },
+      "pasivo_total": {
+        "method": "keyword",
+        "matched_term": "total pasivos",
+        "row_snippet": "total pasivos 464,107 470,405 (1.3)"
+      },
+      "utilidad_operacion": {
+        "method": "keyword",
+        "matched_term": "utilidad de operación",
+        "row_snippet": "utilidad de operación 13,565 6.9 12,936 7.3 4.9 1.7"
+      },
+      "gastos_financieros": {
+        "method": "keyword",
+        "matched_term": "gastos de financiamiento",
+        "row_snippet": "gastos de financiamiento, neto 1,413 3,377 (58.2)"
+      },
+      "utilidad_neta": {
+        "method": "keyword",
+        "matched_term": "utilidad neta",
+        "row_snippet": "(pérdida) utilidad neta consolidada 8,943 5,794 54.3"
+      },
+      "impuestos": {
+        "method": "keyword",
+        "matched_term": "isr",
+        "row_snippet": "isr 4,781 3,356 42.5"
+      }
+    },
+    "_warnings": null
+  },
+  "kpis": [
+    {
+      "label": "Apalancamiento",
+      "value": "0.54",
+      "status": "warn"
+    },
+    {
+      "label": "Razón de Cobertura de Intereses",
+      "value": "9.60",
+      "status": "ok"
+    },
+    {
+      "label": "Estabilidad Financiera",
+      "value": "1.18",
+      "status": "warn"
+    }
+  ]
+}

--- a/backend/tests/golden/femsa_estructura.json
+++ b/backend/tests/golden/femsa_estructura.json
@@ -39,7 +39,37 @@
         "row_snippet": "total pasivo circulante 203,393 202,930 0.2"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "pasivo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Pasivo"
+      },
+      "capital_social": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital social"
+      },
+      "capital_contable": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital Contable"
+      },
+      "activo_fijo": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Propiedades, planta y equipo"
+      },
+      "pasivo_largo_plazo": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Pasivo a largo plazo"
+      },
+      "pasivo_circulante": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Pasivo a corto plazo"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/femsa_estructura.json
+++ b/backend/tests/golden/femsa_estructura.json
@@ -1,42 +1,42 @@
 {
   "datos_crudos": {
-    "activo_total": 333116000000.0,
-    "pasivo_total": 186246000000.0,
+    "activo_total": 855883000000.0,
+    "pasivo_total": 464107000000.0,
     "capital_social": 0.0,
-    "capital_contable": 146870000000.0,
-    "activo_fijo": 111725000000.0,
-    "pasivo_largo_plazo": 107901000000.0,
+    "capital_contable": 391776000000.0,
+    "activo_fijo": 181957000000.0,
+    "pasivo_largo_plazo": 260714000000.0,
     "multiplicador": 1000000,
     "_extraction_trace": {
       "activo_total": {
         "method": "keyword",
         "matched_term": "total activos",
-        "row_snippet": "total activos 333,116 total capital 146,870"
+        "row_snippet": "total activos 855,883 851,536 0.5"
       },
       "activo_fijo": {
         "method": "keyword",
         "matched_term": "propiedad, planta y equipo",
-        "row_snippet": "total propiedad, planta y equipo, neto 111,725 otros pasivos de largo plazo 22,811"
+        "row_snippet": "propiedad, planta y equipo, neto 181,957 177,511 2.5"
       },
       "pasivo_total": {
         "method": "keyword",
-        "matched_term": "total pasivo",
-        "row_snippet": "activos por derechos de uso 3,461 total pasivo 186,246"
+        "matched_term": "total pasivos",
+        "row_snippet": "total pasivos 464,107 470,405 (1.3)"
       },
       "capital_contable": {
         "method": "keyword",
-        "matched_term": "total capital",
-        "row_snippet": "total activos 333,116 total capital 146,870"
+        "matched_term": "total capital contable",
+        "row_snippet": "total capital contable 391,776 381,131 2.8"
       },
       "pasivo_largo_plazo": {
         "method": "math_rescue",
         "formula": "pasivo_total - pasivo_circulante",
-        "value": 107901000000.0
+        "value": 260714000000.0
       },
       "pasivo_circulante": {
         "method": "keyword",
         "matched_term": "pasivo circulante",
-        "row_snippet": "total activos circulantes 86,141 pasivo circulante 78,345"
+        "row_snippet": "total pasivo circulante 203,393 202,930 0.2"
       }
     },
     "_warnings": null
@@ -44,13 +44,13 @@
   "kpis": [
     {
       "label": "Solvencia General",
-      "value": "1.79",
+      "value": "1.84",
       "status": "ok"
     },
     {
       "label": "Seguridad a largo plazo",
-      "value": "1.04",
-      "status": "ok"
+      "value": "0.70",
+      "status": "warn"
     },
     {
       "label": "Inmovilización de Cap. Social",
@@ -59,7 +59,7 @@
     },
     {
       "label": "Inmovilización de Cap. Contable",
-      "value": "0.76",
+      "value": "0.46",
       "status": "ok"
     }
   ]

--- a/backend/tests/golden/femsa_liquidez.json
+++ b/backend/tests/golden/femsa_liquidez.json
@@ -21,7 +21,21 @@
         "row_snippet": "inventarios 66,548 67,464 (1.4)"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "activo_circulante": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Activo a corto plazo (circulante)"
+      },
+      "pasivo_circulante": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Pasivo a corto plazo"
+      },
+      "inventario": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Inventarios"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/femsa_liquidez.json
+++ b/backend/tests/golden/femsa_liquidez.json
@@ -1,24 +1,24 @@
 {
   "datos_crudos": {
-    "activo_circulante": 1655000.0,
-    "pasivo_circulante": 528000.0,
-    "inventario": 900000.0,
-    "multiplicador": 1,
+    "activo_circulante": 333560000000.0,
+    "pasivo_circulante": 203393000000.0,
+    "inventario": 66548000000.0,
+    "multiplicador": 1000000,
     "_extraction_trace": {
       "activo_circulante": {
         "method": "keyword",
         "matched_term": "total activo circulante",
-        "row_snippet": "total activo circulante 1,655,000 pasivo l.p. 1,200,000"
+        "row_snippet": "total activo circulante 333,560 342,311 (2.6)"
       },
       "pasivo_circulante": {
         "method": "keyword",
-        "matched_term": "pasivo a corto plazo",
-        "row_snippet": "seguros anticipados 25,000 total pasivo a corto plazo 528,000"
+        "matched_term": "pasivo circulante",
+        "row_snippet": "total pasivo circulante 203,393 202,930 0.2"
       },
       "inventario": {
         "method": "keyword",
         "matched_term": "inventarios",
-        "row_snippet": "inventarios 900,000 isr por pagar 96,000"
+        "row_snippet": "inventarios 66,548 67,464 (1.4)"
       }
     },
     "_warnings": null
@@ -26,17 +26,17 @@
   "kpis": [
     {
       "label": "Razón de Liquidez",
-      "value": "3.13",
+      "value": "1.64",
       "status": "ok"
     },
     {
       "label": "Prueba del Ácido",
-      "value": "1.43",
+      "value": "1.31",
       "status": "ok"
     },
     {
       "label": "Capital de Trabajo",
-      "value": "$1,127,000.00",
+      "value": "$130,167,000,000.00",
       "status": "ok"
     }
   ]

--- a/backend/tests/golden/femsa_rentabilidad.json
+++ b/backend/tests/golden/femsa_rentabilidad.json
@@ -1,30 +1,30 @@
 {
   "datos_crudos": {
-    "utilidad_neta": 4735000000.0,
-    "ventas_netas": 70925000000.0,
-    "activo_total": 333116000000.0,
-    "capital_contable": 146870000000.0,
+    "utilidad_neta": 8943000000.0,
+    "ventas_netas": 195820000000.0,
+    "activo_total": 855883000000.0,
+    "capital_contable": 391776000000.0,
     "multiplicador": 1000000,
     "_extraction_trace": {
       "ventas_netas": {
         "method": "keyword",
         "matched_term": "ingresos totales",
-        "row_snippet": "ingresos totales 70,925 100.0% 70,157 100.0%"
+        "row_snippet": "ingresos totales 195,820 100.0 176,334 100.0 11.1 5.6"
       },
       "utilidad_neta": {
         "method": "keyword",
         "matched_term": "utilidad neta",
-        "row_snippet": "utilidad neta consolidada 4,735 5,492"
+        "row_snippet": "(pérdida) utilidad neta consolidada 8,943 5,794 54.3"
       },
       "activo_total": {
         "method": "keyword",
         "matched_term": "total activos",
-        "row_snippet": "total activos 333,116 total capital 146,870"
+        "row_snippet": "total activos 855,883 851,536 0.5"
       },
       "capital_contable": {
         "method": "keyword",
-        "matched_term": "total capital",
-        "row_snippet": "total activos 333,116 total capital 146,870"
+        "matched_term": "total capital contable",
+        "row_snippet": "total capital contable 391,776 381,131 2.8"
       }
     },
     "_warnings": null
@@ -32,18 +32,18 @@
   "kpis": [
     {
       "label": "Margen de Rentabilidad",
-      "value": "6.68%",
+      "value": "4.57%",
       "status": "warn"
     },
     {
       "label": "Rendimiento sobre Activos Totales (RAT)",
-      "value": "1.42%",
-      "status": "ok"
+      "value": "1.04%",
+      "status": "warn"
     },
     {
       "label": "Rendimiento sobre el Patrimonio",
-      "value": "3.22%",
-      "status": "ok"
+      "value": "2.28%",
+      "status": "warn"
     }
   ]
 }

--- a/backend/tests/golden/femsa_rentabilidad.json
+++ b/backend/tests/golden/femsa_rentabilidad.json
@@ -27,7 +27,25 @@
         "row_snippet": "total capital contable 391,776 381,131 2.8"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "utilidad_neta": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Utilidad / pérdida del ejercicio"
+      },
+      "ventas_netas": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Ventas o Ingresos netos"
+      },
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "capital_contable": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital Contable"
+      }
+    }
   },
   "kpis": [
     {
@@ -38,12 +56,14 @@
     {
       "label": "Rendimiento sobre Activos Totales (RAT)",
       "value": "1.04%",
-      "status": "warn"
+      "status": "warn",
+      "nota_periodo": "valor trimestral"
     },
     {
       "label": "Rendimiento sobre el Patrimonio",
       "value": "2.28%",
-      "status": "warn"
+      "status": "warn",
+      "nota_periodo": "valor trimestral"
     }
   ]
 }

--- a/backend/tests/golden/femsa_rotacion.json
+++ b/backend/tests/golden/femsa_rotacion.json
@@ -1,43 +1,43 @@
 {
   "datos_crudos": {
-    "cuentas_por_cobrar": 17749000000.0,
-    "inventario": 14814000000.0,
-    "activo_fijo_neto": 111725000000.0,
-    "activo_total": 333116000000.0,
-    "ventas_netas": 70925000000.0,
-    "costo_ventas": 37670000000.0,
+    "cuentas_por_cobrar": 41818000000.0,
+    "inventario": 66548000000.0,
+    "activo_fijo_neto": 181957000000.0,
+    "activo_total": 855883000000.0,
+    "ventas_netas": 195820000000.0,
+    "costo_ventas": 116902000000.0,
     "dias_calculo": 90,
     "multiplicador": 1000000,
     "_extraction_trace": {
       "cuentas_por_cobrar": {
         "method": "keyword",
         "matched_term": "cuentas por cobrar",
-        "row_snippet": "total cuentas por cobrar 17,749 proveedores 29,385"
+        "row_snippet": "cuentas por cobrar 41,818 43,192 (3.2)"
       },
       "inventario": {
         "method": "keyword",
         "matched_term": "inventarios",
-        "row_snippet": "inventarios 14,814 vencimiento cp pasivo arrendamiento 952"
+        "row_snippet": "inventarios 66,548 67,464 (1.4)"
       },
       "activo_fijo": {
         "method": "keyword",
         "matched_term": "propiedad, planta y equipo",
-        "row_snippet": "total propiedad, planta y equipo, neto 111,725 otros pasivos de largo plazo 22,811"
+        "row_snippet": "propiedad, planta y equipo, neto 181,957 177,511 2.5"
       },
       "activo_total": {
         "method": "keyword",
         "matched_term": "total activos",
-        "row_snippet": "total activos 333,116 total capital 146,870"
+        "row_snippet": "total activos 855,883 851,536 0.5"
       },
       "ventas_netas": {
         "method": "keyword",
         "matched_term": "ingresos totales",
-        "row_snippet": "ingresos totales 70,925 100.0% 70,157 100.0%"
+        "row_snippet": "ingresos totales 195,820 100.0 176,334 100.0 11.1 5.6"
       },
       "costo_de_ventas": {
         "method": "keyword",
         "matched_term": "costo de ventas",
-        "row_snippet": "costo de ventas 37,670 53.1% 38,324 54.6%"
+        "row_snippet": "costo de ventas 116,902 59.7 108,157 61.3 8.1"
       }
     },
     "_warnings": null
@@ -45,27 +45,27 @@
   "kpis": [
     {
       "label": "Rotación de la Cartera",
-      "value": "4.00",
+      "value": "4.68",
       "status": "ok"
     },
     {
       "label": "Periodo Promedio de Recaudo",
-      "value": "23 días",
+      "value": "19 días",
       "status": "ok"
     },
     {
       "label": "Rotación de Inventarios",
-      "value": "2.54",
+      "value": "1.76",
       "status": "ok"
     },
     {
       "label": "Rotación de Activos Fijos",
-      "value": "0.63",
+      "value": "1.08",
       "status": "ok"
     },
     {
       "label": "Rotación de Activos Totales",
-      "value": "0.21",
+      "value": "0.23",
       "status": "warn"
     }
   ]

--- a/backend/tests/golden/femsa_rotacion.json
+++ b/backend/tests/golden/femsa_rotacion.json
@@ -40,13 +40,40 @@
         "row_snippet": "costo de ventas 116,902 59.7 108,157 61.3 8.1"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "cuentas_por_cobrar": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Cuentas por cobrar a clientes"
+      },
+      "inventario": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Inventarios"
+      },
+      "activo_fijo": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Propiedades, planta y equipo"
+      },
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "ventas_netas": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Ventas o Ingresos netos"
+      },
+      "costo_de_ventas": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Costo de ventas"
+      }
+    }
   },
   "kpis": [
     {
       "label": "Rotación de la Cartera",
       "value": "4.68",
-      "status": "ok"
+      "status": "ok",
+      "nota_periodo": "valor trimestral"
     },
     {
       "label": "Periodo Promedio de Recaudo",
@@ -56,17 +83,20 @@
     {
       "label": "Rotación de Inventarios",
       "value": "1.76",
-      "status": "ok"
+      "status": "ok",
+      "nota_periodo": "valor trimestral"
     },
     {
       "label": "Rotación de Activos Fijos",
       "value": "1.08",
-      "status": "ok"
+      "status": "ok",
+      "nota_periodo": "valor trimestral"
     },
     {
       "label": "Rotación de Activos Totales",
       "value": "0.23",
-      "status": "warn"
+      "status": "warn",
+      "nota_periodo": "valor trimestral"
     }
   ]
 }

--- a/backend/tests/golden/gcmk_endeudamiento.json
+++ b/backend/tests/golden/gcmk_endeudamiento.json
@@ -37,7 +37,37 @@
         "method": "not_found"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "pasivo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Pasivo"
+      },
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "capital_contable": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital Contable"
+      },
+      "utilidad_operacion": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Utilidad de operación"
+      },
+      "gastos_financieros": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Gastos financieros (Intereses a cargo)"
+      },
+      "utilidad_neta": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Utilidad / pérdida del ejercicio"
+      },
+      "impuestos": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Impuestos a la utilidad"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/gcmk_endeudamiento.json
+++ b/backend/tests/golden/gcmk_endeudamiento.json
@@ -5,7 +5,39 @@
     "capital_social": 8932937.18,
     "utilidad_operacion": 165258.77,
     "intereses": 0.0,
-    "multiplicador": 1
+    "multiplicador": 1,
+    "_extraction_trace": {
+      "activo_total": {
+        "method": "keyword",
+        "matched_term": "total de activos",
+        "row_snippet": "total de activos 7,860,188.61"
+      },
+      "capital_contable": {
+        "method": "keyword",
+        "matched_term": "capital contable",
+        "row_snippet": "equipo automotriz 1,911,468.71 capital contable 8,932,937.18"
+      },
+      "pasivo_total": {
+        "method": "math_rescue",
+        "formula": "activo_total - capital_contable",
+        "value": -1072748.57
+      },
+      "utilidad_operacion": {
+        "method": "keyword",
+        "matched_term": "utilidad de operacion",
+        "row_snippet": "utilidad de operacion 165,258.77 33.30 3,792,675.03 44.18"
+      },
+      "gastos_financieros": {
+        "method": "not_found"
+      },
+      "utilidad_neta": {
+        "method": "not_found"
+      },
+      "impuestos": {
+        "method": "not_found"
+      }
+    },
+    "_warnings": null
   },
   "kpis": [
     {

--- a/backend/tests/golden/gcmk_estructura.json
+++ b/backend/tests/golden/gcmk_estructura.json
@@ -37,7 +37,37 @@
         "row_snippet": "iva retenido 6,200.47 pasivo circulante -1,072,748.57"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "pasivo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Pasivo"
+      },
+      "capital_social": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital social"
+      },
+      "capital_contable": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital Contable"
+      },
+      "activo_fijo": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Propiedades, planta y equipo"
+      },
+      "pasivo_largo_plazo": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Pasivo a largo plazo"
+      },
+      "pasivo_circulante": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Pasivo a corto plazo"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/gcmk_estructura.json
+++ b/backend/tests/golden/gcmk_estructura.json
@@ -6,7 +6,38 @@
     "capital_contable": 8932937.18,
     "activo_fijo": 4646054.71,
     "pasivo_largo_plazo": 0.0,
-    "multiplicador": 1
+    "multiplicador": 1,
+    "_extraction_trace": {
+      "activo_total": {
+        "method": "keyword",
+        "matched_term": "total de activos",
+        "row_snippet": "total de activos 7,860,188.61"
+      },
+      "activo_fijo": {
+        "method": "keyword",
+        "matched_term": "activo fijo",
+        "row_snippet": "activo fijo 4,646,054.71"
+      },
+      "pasivo_total": {
+        "method": "math_rescue",
+        "formula": "activo_total - capital_contable",
+        "value": -1072748.57
+      },
+      "capital_contable": {
+        "method": "keyword",
+        "matched_term": "capital contable",
+        "row_snippet": "equipo automotriz 1,911,468.71 capital contable 8,932,937.18"
+      },
+      "pasivo_largo_plazo": {
+        "method": "not_found"
+      },
+      "pasivo_circulante": {
+        "method": "keyword",
+        "matched_term": "pasivo circulante",
+        "row_snippet": "iva retenido 6,200.47 pasivo circulante -1,072,748.57"
+      }
+    },
+    "_warnings": null
   },
   "kpis": [
     {

--- a/backend/tests/golden/gcmk_liquidez.json
+++ b/backend/tests/golden/gcmk_liquidez.json
@@ -19,7 +19,21 @@
         "method": "not_found"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "activo_circulante": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Activo a corto plazo (circulante)"
+      },
+      "pasivo_circulante": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Pasivo a corto plazo"
+      },
+      "inventario": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Inventarios"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/gcmk_rentabilidad.json
+++ b/backend/tests/golden/gcmk_rentabilidad.json
@@ -30,7 +30,25 @@
         "row_snippet": "equipo automotriz 1,911,468.71 capital contable 8,932,937.18"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "utilidad_neta": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Utilidad / pérdida del ejercicio"
+      },
+      "ventas_netas": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Ventas o Ingresos netos"
+      },
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "capital_contable": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital Contable"
+      }
+    }
   },
   "kpis": [
     {
@@ -41,12 +59,14 @@
     {
       "label": "Rendimiento sobre Activos Totales (RAT)",
       "value": "2.10%",
-      "status": "ok"
+      "status": "ok",
+      "nota_periodo": "valor mensual"
     },
     {
       "label": "Rendimiento sobre el Patrimonio",
       "value": "1.85%",
-      "status": "ok"
+      "status": "ok",
+      "nota_periodo": "valor mensual"
     }
   ]
 }

--- a/backend/tests/golden/gcmk_rentabilidad.json
+++ b/backend/tests/golden/gcmk_rentabilidad.json
@@ -4,7 +4,33 @@
     "ventas_netas": 496288.6,
     "activo_total": 7860188.61,
     "capital_contable": 8932937.18,
-    "multiplicador": 1
+    "multiplicador": 1,
+    "_extraction_trace": {
+      "ventas_netas": {
+        "method": "keyword",
+        "matched_term": "ingresos por servicios",
+        "row_snippet": "ingresos por servicios 496,288.60 100.00 8,585,303.18 100.00"
+      },
+      "utilidad_neta": {
+        "method": "not_found"
+      },
+      "utilidad_antes_impuestos": {
+        "method": "keyword",
+        "matched_term": "utilidad antes de impuestos",
+        "row_snippet": "utilidad antes de impuestos 165,258.77 33.30 3,784,287.01 44.08"
+      },
+      "activo_total": {
+        "method": "keyword",
+        "matched_term": "total de activos",
+        "row_snippet": "total de activos 7,860,188.61"
+      },
+      "capital_contable": {
+        "method": "keyword",
+        "matched_term": "capital contable",
+        "row_snippet": "equipo automotriz 1,911,468.71 capital contable 8,932,937.18"
+      }
+    },
+    "_warnings": null
   },
   "kpis": [
     {

--- a/backend/tests/golden/gcmk_rotacion.json
+++ b/backend/tests/golden/gcmk_rotacion.json
@@ -7,7 +7,36 @@
     "ventas_netas": 496288.6,
     "costo_ventas": 0.0,
     "dias_calculo": 30,
-    "multiplicador": 1
+    "multiplicador": 1,
+    "_extraction_trace": {
+      "cuentas_por_cobrar": {
+        "method": "keyword",
+        "matched_term": "clientes",
+        "row_snippet": "clientes 1,385,929.80 iva cobrado -68,958.08"
+      },
+      "inventario": {
+        "method": "not_found"
+      },
+      "activo_fijo": {
+        "method": "keyword",
+        "matched_term": "activo fijo",
+        "row_snippet": "activo fijo 4,646,054.71"
+      },
+      "activo_total": {
+        "method": "keyword",
+        "matched_term": "total de activos",
+        "row_snippet": "total de activos 7,860,188.61"
+      },
+      "ventas_netas": {
+        "method": "keyword",
+        "matched_term": "ingresos por servicios",
+        "row_snippet": "ingresos por servicios 496,288.60 100.00 8,585,303.18 100.00"
+      },
+      "costo_de_ventas": {
+        "method": "not_found"
+      }
+    },
+    "_warnings": null
   },
   "kpis": [
     {

--- a/backend/tests/golden/gcmk_rotacion.json
+++ b/backend/tests/golden/gcmk_rotacion.json
@@ -36,13 +36,40 @@
         "method": "not_found"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "cuentas_por_cobrar": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Cuentas por cobrar a clientes"
+      },
+      "inventario": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Inventarios"
+      },
+      "activo_fijo": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Propiedades, planta y equipo"
+      },
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "ventas_netas": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Ventas o Ingresos netos"
+      },
+      "costo_de_ventas": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Costo de ventas"
+      }
+    }
   },
   "kpis": [
     {
       "label": "Rotación de la Cartera",
       "value": "0.36",
-      "status": "ok"
+      "status": "ok",
+      "nota_periodo": "valor mensual"
     },
     {
       "label": "Periodo Promedio de Recaudo",
@@ -57,12 +84,14 @@
     {
       "label": "Rotación de Activos Fijos",
       "value": "0.11",
-      "status": "ok"
+      "status": "ok",
+      "nota_periodo": "valor mensual"
     },
     {
       "label": "Rotación de Activos Totales",
       "value": "0.06",
-      "status": "warn"
+      "status": "warn",
+      "nota_periodo": "valor mensual"
     }
   ]
 }

--- a/backend/tests/golden/taas_ene_endeudamiento.json
+++ b/backend/tests/golden/taas_ene_endeudamiento.json
@@ -44,7 +44,37 @@
         "method": "not_found"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "pasivo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Pasivo"
+      },
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "capital_contable": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital Contable"
+      },
+      "utilidad_operacion": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Utilidad de operación"
+      },
+      "gastos_financieros": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Gastos financieros (Intereses a cargo)"
+      },
+      "utilidad_neta": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Utilidad / pérdida del ejercicio"
+      },
+      "impuestos": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Impuestos a la utilidad"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/taas_ene_endeudamiento.json
+++ b/backend/tests/golden/taas_ene_endeudamiento.json
@@ -5,7 +5,46 @@
     "capital_social": 4159419.5,
     "utilidad_operacion": 377343.58999999997,
     "intereses": 14669.35,
-    "multiplicador": 1
+    "multiplicador": 1,
+    "_extraction_trace": {
+      "activo_total": {
+        "method": "keyword",
+        "matched_term": "total activos:",
+        "row_snippet": "total activos: 4,582,804.97 total pasivo + capital: 4,582,804.97"
+      },
+      "capital_contable": {
+        "method": "keyword",
+        "matched_term": "capital contable",
+        "row_snippet": "maquinaria y equipo 395,600.00 capital contable 4,159,419.50"
+      },
+      "pasivo_total": {
+        "method": "math_rescue",
+        "formula": "activo_total - capital_contable",
+        "value": 423385.47
+      },
+      "utilidad_operacion": {
+        "method": "math_rescue",
+        "formula": "utilidad_neta + impuestos + gastos_financieros",
+        "value": 377343.59
+      },
+      "gastos_financieros": {
+        "method": "keyword",
+        "matched_term": "gastos financieros",
+        "row_snippet": "gastos financieros 14,669.35 14,669.35"
+      },
+      "utilidad_neta": {
+        "method": "keyword",
+        "matched_term": "utilidad total",
+        "row_snippet": "utilidad total 362,674.24 362,674.24"
+      },
+      "impuestos": {
+        "method": "not_found"
+      },
+      "utilidad_antes_impuestos": {
+        "method": "not_found"
+      }
+    },
+    "_warnings": null
   },
   "kpis": [
     {

--- a/backend/tests/golden/taas_ene_estructura.json
+++ b/backend/tests/golden/taas_ene_estructura.json
@@ -6,7 +6,40 @@
     "capital_contable": 4159419.5,
     "activo_fijo": 1729400.0,
     "pasivo_largo_plazo": -0.0,
-    "multiplicador": 1
+    "multiplicador": 1,
+    "_extraction_trace": {
+      "activo_total": {
+        "method": "keyword",
+        "matched_term": "total activos:",
+        "row_snippet": "total activos: 4,582,804.97 total pasivo + capital: 4,582,804.97"
+      },
+      "activo_fijo": {
+        "method": "keyword",
+        "matched_term": "activo a largo plazo",
+        "row_snippet": "activo a largo plazo 1,729,400.00 capital"
+      },
+      "pasivo_total": {
+        "method": "math_rescue",
+        "formula": "activo_total - capital_contable",
+        "value": 423385.47
+      },
+      "capital_contable": {
+        "method": "keyword",
+        "matched_term": "capital contable",
+        "row_snippet": "maquinaria y equipo 395,600.00 capital contable 4,159,419.50"
+      },
+      "pasivo_largo_plazo": {
+        "method": "math_rescue",
+        "formula": "pasivo_total - pasivo_circulante",
+        "value": -0.0
+      },
+      "pasivo_circulante": {
+        "method": "keyword",
+        "matched_term": "pasivo a corto plazo",
+        "row_snippet": "activo a corto plazo 2,853,404.97 pasivo a corto plazo 423,385.47"
+      }
+    },
+    "_warnings": null
   },
   "kpis": [
     {

--- a/backend/tests/golden/taas_ene_estructura.json
+++ b/backend/tests/golden/taas_ene_estructura.json
@@ -39,7 +39,37 @@
         "row_snippet": "activo a corto plazo 2,853,404.97 pasivo a corto plazo 423,385.47"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "pasivo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Pasivo"
+      },
+      "capital_social": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital social"
+      },
+      "capital_contable": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital Contable"
+      },
+      "activo_fijo": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Propiedades, planta y equipo"
+      },
+      "pasivo_largo_plazo": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Pasivo a largo plazo"
+      },
+      "pasivo_circulante": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Pasivo a corto plazo"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/taas_ene_liquidez.json
+++ b/backend/tests/golden/taas_ene_liquidez.json
@@ -3,7 +3,23 @@
     "activo_circulante": 2853404.97,
     "pasivo_circulante": 423385.47,
     "inventario": 0.0,
-    "multiplicador": 1
+    "multiplicador": 1,
+    "_extraction_trace": {
+      "activo_circulante": {
+        "method": "keyword",
+        "matched_term": "activo a corto plazo",
+        "row_snippet": "activo a corto plazo 2,853,404.97 pasivo a corto plazo 423,385.47"
+      },
+      "pasivo_circulante": {
+        "method": "keyword",
+        "matched_term": "pasivo a corto plazo",
+        "row_snippet": "activo a corto plazo 2,853,404.97 pasivo a corto plazo 423,385.47"
+      },
+      "inventario": {
+        "method": "not_found"
+      }
+    },
+    "_warnings": null
   },
   "kpis": [
     {

--- a/backend/tests/golden/taas_ene_liquidez.json
+++ b/backend/tests/golden/taas_ene_liquidez.json
@@ -19,7 +19,21 @@
         "method": "not_found"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "activo_circulante": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Activo a corto plazo (circulante)"
+      },
+      "pasivo_circulante": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Pasivo a corto plazo"
+      },
+      "inventario": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Inventarios"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/taas_ene_rentabilidad.json
+++ b/backend/tests/golden/taas_ene_rentabilidad.json
@@ -25,7 +25,25 @@
         "row_snippet": "maquinaria y equipo 395,600.00 capital contable 4,159,419.50"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "utilidad_neta": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Utilidad / pérdida del ejercicio"
+      },
+      "ventas_netas": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Ventas o Ingresos netos"
+      },
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "capital_contable": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital Contable"
+      }
+    }
   },
   "kpis": [
     {
@@ -36,12 +54,14 @@
     {
       "label": "Rendimiento sobre Activos Totales (RAT)",
       "value": "7.91%",
-      "status": "ok"
+      "status": "ok",
+      "nota_periodo": "valor mensual"
     },
     {
       "label": "Rendimiento sobre el Patrimonio",
       "value": "8.72%",
-      "status": "ok"
+      "status": "ok",
+      "nota_periodo": "valor mensual"
     }
   ]
 }

--- a/backend/tests/golden/taas_ene_rentabilidad.json
+++ b/backend/tests/golden/taas_ene_rentabilidad.json
@@ -4,7 +4,28 @@
     "ventas_netas": 479242.08,
     "activo_total": 4582804.97,
     "capital_contable": 4159419.5,
-    "multiplicador": 1
+    "multiplicador": 1,
+    "_extraction_trace": {
+      "ventas_netas": {
+        "method": "not_found"
+      },
+      "utilidad_neta": {
+        "method": "keyword",
+        "matched_term": "utilidad total",
+        "row_snippet": "utilidad total 362,674.24 362,674.24"
+      },
+      "activo_total": {
+        "method": "keyword",
+        "matched_term": "total activos:",
+        "row_snippet": "total activos: 4,582,804.97 total pasivo + capital: 4,582,804.97"
+      },
+      "capital_contable": {
+        "method": "keyword",
+        "matched_term": "capital contable",
+        "row_snippet": "maquinaria y equipo 395,600.00 capital contable 4,159,419.50"
+      }
+    },
+    "_warnings": null
   },
   "kpis": [
     {

--- a/backend/tests/golden/taas_ene_rotacion.json
+++ b/backend/tests/golden/taas_ene_rotacion.json
@@ -36,13 +36,40 @@
         "row_snippet": "costo de venta y/o servicio 11,048.73 11,048.73"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "cuentas_por_cobrar": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Cuentas por cobrar a clientes"
+      },
+      "inventario": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Inventarios"
+      },
+      "activo_fijo": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Propiedades, planta y equipo"
+      },
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "ventas_netas": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Ventas o Ingresos netos"
+      },
+      "costo_de_ventas": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Costo de ventas"
+      }
+    }
   },
   "kpis": [
     {
       "label": "Rotación de la Cartera",
       "value": "0.29",
-      "status": "warn"
+      "status": "warn",
+      "nota_periodo": "valor mensual"
     },
     {
       "label": "Periodo Promedio de Recaudo",
@@ -57,12 +84,14 @@
     {
       "label": "Rotación de Activos Fijos",
       "value": "0.28",
-      "status": "ok"
+      "status": "ok",
+      "nota_periodo": "valor mensual"
     },
     {
       "label": "Rotación de Activos Totales",
       "value": "0.10",
-      "status": "ok"
+      "status": "ok",
+      "nota_periodo": "valor mensual"
     }
   ]
 }

--- a/backend/tests/golden/taas_ene_rotacion.json
+++ b/backend/tests/golden/taas_ene_rotacion.json
@@ -7,7 +7,36 @@
     "ventas_netas": 479242.08,
     "costo_ventas": 69683.62,
     "dias_calculo": 30,
-    "multiplicador": 1
+    "multiplicador": 1,
+    "_extraction_trace": {
+      "cuentas_por_cobrar": {
+        "method": "keyword",
+        "matched_term": "clientes",
+        "row_snippet": "clientes 1,643,223.10 impuestos retenidos 3,882.45"
+      },
+      "inventario": {
+        "method": "not_found"
+      },
+      "activo_fijo": {
+        "method": "keyword",
+        "matched_term": "activo a largo plazo",
+        "row_snippet": "activo a largo plazo 1,729,400.00 capital"
+      },
+      "activo_total": {
+        "method": "keyword",
+        "matched_term": "total activos:",
+        "row_snippet": "total activos: 4,582,804.97 total pasivo + capital: 4,582,804.97"
+      },
+      "ventas_netas": {
+        "method": "not_found"
+      },
+      "costo_de_ventas": {
+        "method": "keyword",
+        "matched_term": "costo de venta",
+        "row_snippet": "costo de venta y/o servicio 11,048.73 11,048.73"
+      }
+    },
+    "_warnings": null
   },
   "kpis": [
     {

--- a/backend/tests/golden/taas_mar_endeudamiento.json
+++ b/backend/tests/golden/taas_mar_endeudamiento.json
@@ -44,7 +44,37 @@
         "method": "not_found"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "pasivo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Pasivo"
+      },
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "capital_contable": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital Contable"
+      },
+      "utilidad_operacion": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Utilidad de operación"
+      },
+      "gastos_financieros": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Gastos financieros (Intereses a cargo)"
+      },
+      "utilidad_neta": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Utilidad / pérdida del ejercicio"
+      },
+      "impuestos": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Impuestos a la utilidad"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/taas_mar_endeudamiento.json
+++ b/backend/tests/golden/taas_mar_endeudamiento.json
@@ -5,7 +5,46 @@
     "capital_social": 4460926.36,
     "utilidad_operacion": 377343.58999999997,
     "intereses": 14669.35,
-    "multiplicador": 1
+    "multiplicador": 1,
+    "_extraction_trace": {
+      "activo_total": {
+        "method": "keyword",
+        "matched_term": "total activos:",
+        "row_snippet": "total activos: 4,828,580.34 total pasivo + capital: 4,828,580.34"
+      },
+      "capital_contable": {
+        "method": "keyword",
+        "matched_term": "capital contable",
+        "row_snippet": "maquinaria y equipo 395,600.00 capital contable 4,460,926.36"
+      },
+      "pasivo_total": {
+        "method": "math_rescue",
+        "formula": "activo_total - capital_contable",
+        "value": 367653.98
+      },
+      "utilidad_operacion": {
+        "method": "math_rescue",
+        "formula": "utilidad_neta + impuestos + gastos_financieros",
+        "value": 377343.59
+      },
+      "gastos_financieros": {
+        "method": "keyword",
+        "matched_term": "gastos financieros",
+        "row_snippet": "gastos financieros 14,669.35 3,524.77 9,904.81 28,098.93"
+      },
+      "utilidad_neta": {
+        "method": "keyword",
+        "matched_term": "utilidad total",
+        "row_snippet": "utilidad total 362,674.24 140,588.37 145,888.78 664,181.10"
+      },
+      "impuestos": {
+        "method": "not_found"
+      },
+      "utilidad_antes_impuestos": {
+        "method": "not_found"
+      }
+    },
+    "_warnings": null
   },
   "kpis": [
     {

--- a/backend/tests/golden/taas_mar_estructura.json
+++ b/backend/tests/golden/taas_mar_estructura.json
@@ -6,7 +6,40 @@
     "capital_contable": 4460926.36,
     "activo_fijo": 1729400.0,
     "pasivo_largo_plazo": -0.0,
-    "multiplicador": 1
+    "multiplicador": 1,
+    "_extraction_trace": {
+      "activo_total": {
+        "method": "keyword",
+        "matched_term": "total activos:",
+        "row_snippet": "total activos: 4,828,580.34 total pasivo + capital: 4,828,580.34"
+      },
+      "activo_fijo": {
+        "method": "keyword",
+        "matched_term": "activo a largo plazo",
+        "row_snippet": "activo a largo plazo 1,729,400.00 capital"
+      },
+      "pasivo_total": {
+        "method": "math_rescue",
+        "formula": "activo_total - capital_contable",
+        "value": 367653.98
+      },
+      "capital_contable": {
+        "method": "keyword",
+        "matched_term": "capital contable",
+        "row_snippet": "maquinaria y equipo 395,600.00 capital contable 4,460,926.36"
+      },
+      "pasivo_largo_plazo": {
+        "method": "math_rescue",
+        "formula": "pasivo_total - pasivo_circulante",
+        "value": -0.0
+      },
+      "pasivo_circulante": {
+        "method": "keyword",
+        "matched_term": "pasivo a corto plazo",
+        "row_snippet": "activo a corto plazo 3,099,180.34 pasivo a corto plazo 367,653.98"
+      }
+    },
+    "_warnings": null
   },
   "kpis": [
     {

--- a/backend/tests/golden/taas_mar_estructura.json
+++ b/backend/tests/golden/taas_mar_estructura.json
@@ -39,7 +39,37 @@
         "row_snippet": "activo a corto plazo 3,099,180.34 pasivo a corto plazo 367,653.98"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "pasivo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Pasivo"
+      },
+      "capital_social": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital social"
+      },
+      "capital_contable": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital Contable"
+      },
+      "activo_fijo": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Propiedades, planta y equipo"
+      },
+      "pasivo_largo_plazo": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Pasivo a largo plazo"
+      },
+      "pasivo_circulante": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Pasivo a corto plazo"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/taas_mar_liquidez.json
+++ b/backend/tests/golden/taas_mar_liquidez.json
@@ -3,7 +3,23 @@
     "activo_circulante": 3099180.34,
     "pasivo_circulante": 367653.98,
     "inventario": 0.0,
-    "multiplicador": 1
+    "multiplicador": 1,
+    "_extraction_trace": {
+      "activo_circulante": {
+        "method": "keyword",
+        "matched_term": "activo a corto plazo",
+        "row_snippet": "activo a corto plazo 3,099,180.34 pasivo a corto plazo 367,653.98"
+      },
+      "pasivo_circulante": {
+        "method": "keyword",
+        "matched_term": "pasivo a corto plazo",
+        "row_snippet": "activo a corto plazo 3,099,180.34 pasivo a corto plazo 367,653.98"
+      },
+      "inventario": {
+        "method": "not_found"
+      }
+    },
+    "_warnings": null
   },
   "kpis": [
     {

--- a/backend/tests/golden/taas_mar_liquidez.json
+++ b/backend/tests/golden/taas_mar_liquidez.json
@@ -19,7 +19,21 @@
         "method": "not_found"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "activo_circulante": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Activo a corto plazo (circulante)"
+      },
+      "pasivo_circulante": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Pasivo a corto plazo"
+      },
+      "inventario": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Inventarios"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/taas_mar_rentabilidad.json
+++ b/backend/tests/golden/taas_mar_rentabilidad.json
@@ -25,7 +25,25 @@
         "row_snippet": "maquinaria y equipo 395,600.00 capital contable 4,460,926.36"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "utilidad_neta": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Utilidad / pérdida del ejercicio"
+      },
+      "ventas_netas": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Ventas o Ingresos netos"
+      },
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "capital_contable": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital Contable"
+      }
+    }
   },
   "kpis": [
     {
@@ -36,12 +54,14 @@
     {
       "label": "Rendimiento sobre Activos Totales (RAT)",
       "value": "7.51%",
-      "status": "ok"
+      "status": "ok",
+      "nota_periodo": "valor trimestral"
     },
     {
       "label": "Rendimiento sobre el Patrimonio",
       "value": "8.13%",
-      "status": "ok"
+      "status": "ok",
+      "nota_periodo": "valor trimestral"
     }
   ]
 }

--- a/backend/tests/golden/taas_mar_rentabilidad.json
+++ b/backend/tests/golden/taas_mar_rentabilidad.json
@@ -4,7 +4,28 @@
     "ventas_netas": 479242.08,
     "activo_total": 4828580.34,
     "capital_contable": 4460926.36,
-    "multiplicador": 1
+    "multiplicador": 1,
+    "_extraction_trace": {
+      "ventas_netas": {
+        "method": "not_found"
+      },
+      "utilidad_neta": {
+        "method": "keyword",
+        "matched_term": "utilidad total",
+        "row_snippet": "utilidad total 362,674.24 140,588.37 145,888.78 664,181.10"
+      },
+      "activo_total": {
+        "method": "keyword",
+        "matched_term": "total activos:",
+        "row_snippet": "total activos: 4,828,580.34 total pasivo + capital: 4,828,580.34"
+      },
+      "capital_contable": {
+        "method": "keyword",
+        "matched_term": "capital contable",
+        "row_snippet": "maquinaria y equipo 395,600.00 capital contable 4,460,926.36"
+      }
+    },
+    "_warnings": null
   },
   "kpis": [
     {

--- a/backend/tests/golden/taas_mar_rotacion.json
+++ b/backend/tests/golden/taas_mar_rotacion.json
@@ -36,13 +36,40 @@
         "row_snippet": "costo de venta y/o servicio 11,048.73 15,020.89 15,654.19 26,693.98"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "cuentas_por_cobrar": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Cuentas por cobrar a clientes"
+      },
+      "inventario": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Inventarios"
+      },
+      "activo_fijo": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Propiedades, planta y equipo"
+      },
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "ventas_netas": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Ventas o Ingresos netos"
+      },
+      "costo_de_ventas": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Costo de ventas"
+      }
+    }
   },
   "kpis": [
     {
       "label": "Rotación de la Cartera",
       "value": "0.32",
-      "status": "warn"
+      "status": "warn",
+      "nota_periodo": "valor trimestral"
     },
     {
       "label": "Periodo Promedio de Recaudo",
@@ -57,12 +84,14 @@
     {
       "label": "Rotación de Activos Fijos",
       "value": "0.28",
-      "status": "ok"
+      "status": "ok",
+      "nota_periodo": "valor trimestral"
     },
     {
       "label": "Rotación de Activos Totales",
       "value": "0.10",
-      "status": "danger"
+      "status": "danger",
+      "nota_periodo": "valor trimestral"
     }
   ]
 }

--- a/backend/tests/golden/taas_mar_rotacion.json
+++ b/backend/tests/golden/taas_mar_rotacion.json
@@ -7,7 +7,36 @@
     "ventas_netas": 479242.08,
     "costo_ventas": 69683.62,
     "dias_calculo": 90,
-    "multiplicador": 1
+    "multiplicador": 1,
+    "_extraction_trace": {
+      "cuentas_por_cobrar": {
+        "method": "keyword",
+        "matched_term": "clientes",
+        "row_snippet": "clientes 1,515,323.53 impuestos retenidos 3,882.45"
+      },
+      "inventario": {
+        "method": "not_found"
+      },
+      "activo_fijo": {
+        "method": "keyword",
+        "matched_term": "activo a largo plazo",
+        "row_snippet": "activo a largo plazo 1,729,400.00 capital"
+      },
+      "activo_total": {
+        "method": "keyword",
+        "matched_term": "total activos:",
+        "row_snippet": "total activos: 4,828,580.34 total pasivo + capital: 4,828,580.34"
+      },
+      "ventas_netas": {
+        "method": "not_found"
+      },
+      "costo_de_ventas": {
+        "method": "keyword",
+        "matched_term": "costo de venta",
+        "row_snippet": "costo de venta y/o servicio 11,048.73 15,020.89 15,654.19 26,693.98"
+      }
+    },
+    "_warnings": null
   },
   "kpis": [
     {

--- a/backend/tests/golden/tech_soluciones_endeudamiento.json
+++ b/backend/tests/golden/tech_soluciones_endeudamiento.json
@@ -5,7 +5,45 @@
     "capital_social": 3688000.0,
     "utilidad_operacion": 300000.0,
     "intereses": 45000.0,
-    "multiplicador": 1
+    "multiplicador": 1,
+    "_extraction_trace": {
+      "activo_total": {
+        "method": "keyword",
+        "matched_term": "total activo",
+        "row_snippet": "total activo 6,600,000"
+      },
+      "capital_contable": {
+        "method": "keyword",
+        "matched_term": "total capital contable",
+        "row_snippet": "total capital contable 3,688,000"
+      },
+      "pasivo_total": {
+        "method": "keyword",
+        "matched_term": "total pasivo",
+        "row_snippet": "total pasivo 2,912,000"
+      },
+      "utilidad_operacion": {
+        "method": "keyword",
+        "matched_term": "utilidad de operación",
+        "row_snippet": "utilidad de operación 300,000"
+      },
+      "gastos_financieros": {
+        "method": "keyword",
+        "matched_term": "gastos financieros",
+        "row_snippet": "(-) gastos financieros (intereses) (45,000)"
+      },
+      "utilidad_neta": {
+        "method": "keyword",
+        "matched_term": "utilidad neta",
+        "row_snippet": "utilidad neta 153,000"
+      },
+      "impuestos": {
+        "method": "keyword",
+        "matched_term": "isr",
+        "row_snippet": "(-) isr (30%) (76,500)"
+      }
+    },
+    "_warnings": null
   },
   "kpis": [
     {

--- a/backend/tests/golden/tech_soluciones_endeudamiento.json
+++ b/backend/tests/golden/tech_soluciones_endeudamiento.json
@@ -43,7 +43,37 @@
         "row_snippet": "(-) isr (30%) (76,500)"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "pasivo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Pasivo"
+      },
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "capital_contable": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital Contable"
+      },
+      "utilidad_operacion": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Utilidad de operación"
+      },
+      "gastos_financieros": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Gastos financieros (Intereses a cargo)"
+      },
+      "utilidad_neta": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Utilidad / pérdida del ejercicio"
+      },
+      "impuestos": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Impuestos a la utilidad"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/tech_soluciones_estructura.json
+++ b/backend/tests/golden/tech_soluciones_estructura.json
@@ -6,7 +6,40 @@
     "capital_contable": 3688000.0,
     "activo_fijo": 5035000.0,
     "pasivo_largo_plazo": 2200000.0,
-    "multiplicador": 1
+    "multiplicador": 1,
+    "_extraction_trace": {
+      "activo_total": {
+        "method": "keyword",
+        "matched_term": "total activo",
+        "row_snippet": "total activo 6,600,000"
+      },
+      "activo_fijo": {
+        "method": "keyword",
+        "matched_term": "total activo no circulante",
+        "row_snippet": "total activo no circulante 5,035,000"
+      },
+      "pasivo_total": {
+        "method": "math_rescue",
+        "formula": "activo_total - capital_contable",
+        "value": 2912000.0
+      },
+      "capital_contable": {
+        "method": "keyword",
+        "matched_term": "total capital contable",
+        "row_snippet": "total capital contable 3,688,000"
+      },
+      "pasivo_largo_plazo": {
+        "method": "keyword",
+        "matched_term": "pasivo a largo plazo",
+        "row_snippet": "pasivo a largo plazo 2,200,000"
+      },
+      "pasivo_circulante": {
+        "method": "keyword",
+        "matched_term": "total pasivo corto plazo",
+        "row_snippet": "total pasivo corto plazo 712,000"
+      }
+    },
+    "_warnings": null
   },
   "kpis": [
     {

--- a/backend/tests/golden/tech_soluciones_estructura.json
+++ b/backend/tests/golden/tech_soluciones_estructura.json
@@ -39,7 +39,37 @@
         "row_snippet": "total pasivo corto plazo 712,000"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "pasivo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Pasivo"
+      },
+      "capital_social": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital social"
+      },
+      "capital_contable": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital Contable"
+      },
+      "activo_fijo": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Propiedades, planta y equipo"
+      },
+      "pasivo_largo_plazo": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Pasivo a largo plazo"
+      },
+      "pasivo_circulante": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Pasivo a corto plazo"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/tech_soluciones_liquidez.json
+++ b/backend/tests/golden/tech_soluciones_liquidez.json
@@ -21,7 +21,21 @@
         "row_snippet": "inventarios (hardware para servicios) 280,000"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "activo_circulante": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Activo a corto plazo (circulante)"
+      },
+      "pasivo_circulante": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Pasivo a corto plazo"
+      },
+      "inventario": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Inventarios"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/tech_soluciones_liquidez.json
+++ b/backend/tests/golden/tech_soluciones_liquidez.json
@@ -3,7 +3,25 @@
     "activo_circulante": 1565000.0,
     "pasivo_circulante": 712000.0,
     "inventario": 280000.0,
-    "multiplicador": 1
+    "multiplicador": 1,
+    "_extraction_trace": {
+      "activo_circulante": {
+        "method": "keyword",
+        "matched_term": "total activo circulante",
+        "row_snippet": "total activo circulante 1,565,000"
+      },
+      "pasivo_circulante": {
+        "method": "keyword",
+        "matched_term": "total pasivo corto plazo",
+        "row_snippet": "total pasivo corto plazo 712,000"
+      },
+      "inventario": {
+        "method": "keyword",
+        "matched_term": "inventarios",
+        "row_snippet": "inventarios (hardware para servicios) 280,000"
+      }
+    },
+    "_warnings": null
   },
   "kpis": [
     {

--- a/backend/tests/golden/tech_soluciones_rentabilidad.json
+++ b/backend/tests/golden/tech_soluciones_rentabilidad.json
@@ -4,7 +4,30 @@
     "ventas_netas": 2800000.0,
     "activo_total": 6600000.0,
     "capital_contable": 3688000.0,
-    "multiplicador": 1
+    "multiplicador": 1,
+    "_extraction_trace": {
+      "ventas_netas": {
+        "method": "keyword",
+        "matched_term": "ventas netas",
+        "row_snippet": "ventas netas 2,800,000"
+      },
+      "utilidad_neta": {
+        "method": "keyword",
+        "matched_term": "utilidad neta",
+        "row_snippet": "utilidad neta 153,000"
+      },
+      "activo_total": {
+        "method": "keyword",
+        "matched_term": "total activo",
+        "row_snippet": "total activo 6,600,000"
+      },
+      "capital_contable": {
+        "method": "keyword",
+        "matched_term": "total capital contable",
+        "row_snippet": "total capital contable 3,688,000"
+      }
+    },
+    "_warnings": null
   },
   "kpis": [
     {

--- a/backend/tests/golden/tech_soluciones_rentabilidad.json
+++ b/backend/tests/golden/tech_soluciones_rentabilidad.json
@@ -27,7 +27,25 @@
         "row_snippet": "total capital contable 3,688,000"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "utilidad_neta": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Utilidad / pérdida del ejercicio"
+      },
+      "ventas_netas": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Ventas o Ingresos netos"
+      },
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "capital_contable": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Capital Contable"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/golden/tech_soluciones_rotacion.json
+++ b/backend/tests/golden/tech_soluciones_rotacion.json
@@ -7,7 +7,40 @@
     "ventas_netas": 2800000.0,
     "costo_ventas": 1450000.0,
     "dias_calculo": 360,
-    "multiplicador": 1
+    "multiplicador": 1,
+    "_extraction_trace": {
+      "cuentas_por_cobrar": {
+        "method": "keyword",
+        "matched_term": "cuentas por cobrar",
+        "row_snippet": "cuentas por cobrar (clientes) 650,000"
+      },
+      "inventario": {
+        "method": "keyword",
+        "matched_term": "inventarios",
+        "row_snippet": "inventarios (hardware para servicios) 280,000"
+      },
+      "activo_fijo": {
+        "method": "keyword",
+        "matched_term": "total activo no circulante",
+        "row_snippet": "total activo no circulante 5,035,000"
+      },
+      "activo_total": {
+        "method": "keyword",
+        "matched_term": "total activo",
+        "row_snippet": "total activo 6,600,000"
+      },
+      "ventas_netas": {
+        "method": "keyword",
+        "matched_term": "ventas netas",
+        "row_snippet": "ventas netas 2,800,000"
+      },
+      "costo_de_ventas": {
+        "method": "keyword",
+        "matched_term": "costo de ventas",
+        "row_snippet": "(-) costo de ventas (1,450,000)"
+      }
+    },
+    "_warnings": null
   },
   "kpis": [
     {

--- a/backend/tests/golden/tech_soluciones_rotacion.json
+++ b/backend/tests/golden/tech_soluciones_rotacion.json
@@ -40,7 +40,33 @@
         "row_snippet": "(-) costo de ventas (1,450,000)"
       }
     },
-    "_warnings": null
+    "_warnings": null,
+    "fuentes": {
+      "cuentas_por_cobrar": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Cuentas por cobrar a clientes"
+      },
+      "inventario": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Inventarios"
+      },
+      "activo_fijo": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Propiedades, planta y equipo"
+      },
+      "activo_total": {
+        "norma": "NIF B-6",
+        "cuenta_nif": "Total del Activo"
+      },
+      "ventas_netas": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Ventas o Ingresos netos"
+      },
+      "costo_de_ventas": {
+        "norma": "NIF B-3",
+        "cuenta_nif": "Costo de ventas"
+      }
+    }
   },
   "kpis": [
     {

--- a/backend/tests/test_regression_financial.py
+++ b/backend/tests/test_regression_financial.py
@@ -176,3 +176,72 @@ def test_perfil_sabana_mensual_vs_corporativo_bmv():
         f"sabana={ventas_sabana}, bmv={ventas_bmv}"
     )
     assert ventas_bmv == 10_000, f"corporativo_bmv col_index=0 debe leer el primer valor (10000), obtuvo {ventas_bmv}"
+
+
+# ─── Test detección de periodos por columna (Fase 8) ─────────────────────────
+@pytest.mark.parametrize("texto,esperado", [
+    ("2024", "2024"),
+    ("Enero 2024", "2024-01"),
+    ("ene 2024", "2024-01"),
+    ("Dic 2023", "2023-12"),
+    ("Diciembre 2022", "2022-12"),
+    ("1T24", "2024-Q1"),
+    ("Q1 2024", "2024-Q1"),
+    ("4T 2023", "2023-Q4"),
+    ("2024-03", "2024-03"),
+    ("03/2024", "2024-03"),
+    ("Trimestre 2 2024", "2024-Q2"),
+    ("Cuenta", None),
+    ("", None),
+    ("Total", None),
+])
+def test_parse_period_label(texto, esperado):
+    calc = FinancialCalculator()
+    assert calc._parse_period_label(texto) == esperado
+
+
+def test_detect_period_columns_comparativo_anual():
+    """Documento con 3 años en columnas → mapa {año: data_col_index}.
+
+    Índice posicional entre columnas de periodo (0,1,2…), alineado con _find_value.
+    """
+    calc = FinancialCalculator()
+    tabla = [
+        {"row": 0, "col": 0, "text": "Cuenta"},
+        {"row": 0, "col": 1, "text": "2024"},
+        {"row": 0, "col": 2, "text": "2023"},
+        {"row": 0, "col": 3, "text": "2022"},
+        {"row": 1, "col": 0, "text": "Ventas"},
+        {"row": 1, "col": 1, "text": "100"},
+        {"row": 1, "col": 2, "text": "90"},
+        {"row": 1, "col": 3, "text": "80"},
+    ]
+    detected = calc._detect_period_columns([tabla])
+    assert detected == {"2024": 0, "2023": 1, "2022": 2}
+
+
+def test_detect_period_columns_header_multifila():
+    """Header con mes en una fila y año en la siguiente → combina."""
+    calc = FinancialCalculator()
+    tabla = [
+        {"row": 0, "col": 1, "text": "Enero"},
+        {"row": 0, "col": 2, "text": "Febrero"},
+        {"row": 0, "col": 3, "text": "Marzo"},
+        {"row": 1, "col": 1, "text": "2024"},
+        {"row": 1, "col": 2, "text": "2024"},
+        {"row": 1, "col": 3, "text": "2024"},
+    ]
+    detected = calc._detect_period_columns([tabla])
+    assert detected == {"2024-01": 0, "2024-02": 1, "2024-03": 2}
+
+
+def test_detect_period_columns_corporativo_bmv():
+    """Comparativo trimestral típico BMV: trimestre actual vs anterior."""
+    calc = FinancialCalculator()
+    tabla = [
+        {"row": 0, "col": 0, "text": "Concepto"},
+        {"row": 0, "col": 1, "text": "4T 2024"},
+        {"row": 0, "col": 2, "text": "4T 2023"},
+    ]
+    detected = calc._detect_period_columns([tabla])
+    assert detected == {"2024-Q4": 0, "2023-Q4": 1}

--- a/backend/tests/test_regression_financial.py
+++ b/backend/tests/test_regression_financial.py
@@ -80,7 +80,7 @@ def test_regression(calc, case_name, modulo):
     actual_datos = actual.get("datos_crudos", {})
 
     for key, expected_val in golden_datos.items():
-        if key == "multiplicador":
+        if key in ("multiplicador", "fuentes") or key.startswith("_"):
             continue  # no es un valor extraído, es configuración
         assert key in actual_datos, (
             f"[{case_name}::{modulo}] Falta clave en datos_crudos: '{key}'"
@@ -109,3 +109,70 @@ def test_regression(calc, case_name, modulo):
             f"[{case_name}::{modulo}] KPI '{label}' status cambió: "
             f"esperado='{golden_kpi['status']}', actual='{actual_kpi['status']}'"
         )
+
+
+# ─── Conceptos esperados por módulo ──────────────────────────────────────────
+_FUENTES_ESPERADAS = {
+    "rentabilidad":  {"utilidad_neta", "ventas_netas", "activo_total", "capital_contable"},
+    "liquidez":      {"activo_circulante", "pasivo_circulante", "inventario"},
+    "endeudamiento": {"pasivo_total", "activo_total", "capital_contable", "utilidad_operacion", "gastos_financieros", "utilidad_neta", "impuestos"},
+    "rotacion":      {"cuentas_por_cobrar", "inventario", "activo_fijo", "activo_total", "ventas_netas", "costo_de_ventas"},
+    "estructura":    {"activo_total", "pasivo_total", "capital_social", "capital_contable", "activo_fijo", "pasivo_largo_plazo", "pasivo_circulante"},
+}
+
+# Usamos un solo caso representativo (cocacola) para validar la forma de fuentes
+_FUENTES_CASE = "cocacola"
+
+
+@pytest.mark.parametrize("modulo", MODULOS)
+def test_fuentes_presentes(calc, modulo):
+    """Verifica que datos_crudos incluye 'fuentes' con las claves NIF esperadas."""
+    cfg    = ALL_CASES[_FUENTES_CASE]
+    result = _run_modulo(calc, modulo, cfg)
+    datos  = result.get("datos_crudos", {})
+
+    assert "fuentes" in datos, f"[{modulo}] 'fuentes' ausente en datos_crudos"
+
+    fuentes = datos["fuentes"]
+    assert isinstance(fuentes, dict), f"[{modulo}] 'fuentes' debe ser un dict"
+    assert len(fuentes) > 0, f"[{modulo}] 'fuentes' está vacío"
+
+    for concepto in _FUENTES_ESPERADAS[modulo]:
+        assert concepto in fuentes, f"[{modulo}] Concepto '{concepto}' ausente en fuentes"
+        entrada = fuentes[concepto]
+        assert "norma" in entrada, f"[{modulo}][{concepto}] Falta campo 'norma'"
+        assert "cuenta_nif" in entrada, f"[{modulo}][{concepto}] Falta campo 'cuenta_nif'"
+        assert entrada["norma"].startswith("NIF"), f"[{modulo}][{concepto}] 'norma' no es NIF: {entrada['norma']}"
+
+
+# ─── Test perfiles de formato ────────────────────────────────────────────────
+def _make_sabana_table(n_cols: int = 12):
+    """Genera una tabla sintética con una fila de ventas y n_cols valores mensuales."""
+    cells = [{"row": 0, "col": 0, "text": "Ventas netas"}]
+    for i in range(n_cols):
+        cells.append({"row": 0, "col": i + 1, "text": str((i + 1) * 10_000)})
+    return {"tables_data": [cells]}
+
+
+def test_perfil_sabana_mensual_vs_corporativo_bmv():
+    """corporativo_bmv con col_index=0 en tabla de 12 columnas lee lista[0], NO el francotirador."""
+    calc = FinancialCalculator()
+    calc._embedding_service = None
+
+    tabla = _make_sabana_table(12)
+
+    # sabana_mensual con col_index=0, periodicidad trimestral → suma Q1 (cols 0,1,2) = 10k+20k+30k
+    calc._current_periodicidad = "trimestral"
+    calc._current_formato_perfil = "sabana_mensual"
+    result_sabana = calc.calcular_rentabilidad(tabla, tabla, periodicidad="trimestral", col_index=0, formato_perfil="sabana_mensual")
+    ventas_sabana = result_sabana["datos_crudos"]["ventas_netas"]
+
+    # corporativo_bmv con col_index=0, mismo periodicidad → lee lista[0] = 10k (sin sumar)
+    result_bmv = calc.calcular_rentabilidad(tabla, tabla, periodicidad="trimestral", col_index=0, formato_perfil="corporativo_bmv")
+    ventas_bmv = result_bmv["datos_crudos"]["ventas_netas"]
+
+    assert ventas_sabana != ventas_bmv, (
+        f"sabana_mensual y corporativo_bmv deben producir valores distintos con 12 columnas; "
+        f"sabana={ventas_sabana}, bmv={ventas_bmv}"
+    )
+    assert ventas_bmv == 10_000, f"corporativo_bmv col_index=0 debe leer el primer valor (10000), obtuvo {ventas_bmv}"

--- a/frontend/src/components/app/UserProfileModal.vue
+++ b/frontend/src/components/app/UserProfileModal.vue
@@ -221,7 +221,6 @@ async function handleDeleteAccount() {
 
           <!-- Danger Zone -->
           <div class="danger-zone">
-            <h4>Zona de peligro</h4>
             <div class="danger-content">
               <div class="danger-text">
                 <strong>Eliminar cuenta</strong>

--- a/frontend/src/views/CargaDeDocumentosView.vue
+++ b/frontend/src/views/CargaDeDocumentosView.vue
@@ -14,6 +14,7 @@ import {
   deleteDoc,
   collection,
   serverTimestamp,
+  deleteField,
 } from "firebase/firestore";
 import {
   ref as storageRef,
@@ -462,8 +463,8 @@ async function savePeriodToFirestore(period) {
       {
         label: period.label,
         periodDate: period.periodDate,
-        balanceFile: period.balanceFile,
-        resultsFile: period.resultsFile,
+        balanceFile: period.balanceFile ?? deleteField(),
+        resultsFile: period.resultsFile ?? deleteField(),
         updatedAt: serverTimestamp(),
       },
       { merge: true }

--- a/frontend/src/views/CargaDeDocumentosView.vue
+++ b/frontend/src/views/CargaDeDocumentosView.vue
@@ -738,35 +738,47 @@ function getColIndexFallback(period) {
   return indiceColumna;
 }
 
-// Resuelve el col_index correcto para un periodo.
-// Estrategia: primero pregunta al backend qué columna corresponde al periodo solicitado
-// (basado en los headers reales del documento). Si el backend no encuentra el periodo en
-// ningún documento, cae al fallback histórico que deduce por orden cronológico.
+// Resuelve los col_index correctos para un periodo, devolviendo un índice
+// independiente para Balance y para Estado de Resultados.
+// Cada documento puede tener su propio orden/cantidad de columnas, así que
+// preguntamos al backend por separado y, si el periodo no aparece en alguno
+// de los dos, caemos al fallback histórico para ese documento.
 async function getColIndex(period) {
   const periodKey = getPeriodKey(period);
-  if (!periodKey) return getColIndexFallback(period);
+  const fallback = getColIndexFallback(period);
+
+  if (!periodKey) {
+    return { balance: fallback, resultados: fallback };
+  }
 
   const detected = await detectColumnsForPeriod(period);
-  if (!detected) return getColIndexFallback(period);
-
-  if (detected.balance && detected.balance[periodKey] !== undefined) {
-    return detected.balance[periodKey];
-  }
-  if (detected.resultados && detected.resultados[periodKey] !== undefined) {
-    return detected.resultados[periodKey];
+  if (!detected) {
+    return { balance: fallback, resultados: fallback };
   }
 
-  return getColIndexFallback(period);
+  const idxBalance =
+    detected.balance && detected.balance[periodKey] !== undefined
+      ? detected.balance[periodKey]
+      : fallback;
+  const idxResultados =
+    detected.resultados && detected.resultados[periodKey] !== undefined
+      ? detected.resultados[periodKey]
+      : fallback;
+
+  return { balance: idxBalance, resultados: idxResultados };
 }
 
 async function analyzePeriod(period) {
+  const indices = await getColIndex(period);
   const payload = {
     project_id: projectId,
     period_id: period.id,
     balance_url: period.balanceFile.url,
     resultados_url: period.resultsFile.url,
     periodicidad: periodicity.value,
-    col_index: await getColIndex(period),
+    col_index: indices.balance, // legacy fallback
+    col_index_balance: indices.balance,
+    col_index_resultados: indices.resultados,
     period_date: period.periodDate,
     period_label: period.label,
   };

--- a/frontend/src/views/CargaDeDocumentosView.vue
+++ b/frontend/src/views/CargaDeDocumentosView.vue
@@ -829,7 +829,7 @@ async function saveAnalysisResult(res) {
 async function generateAnalysis() {
   if (completePeriods.value.length === 0) {
     toast({
-      message: "Carga al menos un Balance General y un Estado de Resultados.",
+      message: "Carga al menos un Estado de Situación Financiera y un Estado de Resultados.",
       type: "warning",
     });
     return;
@@ -920,7 +920,7 @@ async function generateAnalysis() {
     <div v-if="isProcessing" class="loading-overlay">
       <div class="loading-content">
         <div class="spinner"></div>
-        <h3>Generando Análisis Financiero...</h3>
+        <h3>Generando análisis financiero...</h3>
         <p>Procesando documentos y ejecutando algoritmos de IA.</p>
       </div>
     </div>
@@ -975,7 +975,7 @@ async function generateAnalysis() {
         <div class="info">
           <span class="material-symbols-outlined">info</span>
           <p>
-            Cada periodo requiere un <strong>Balance General</strong> y un
+            Cada periodo requiere un <strong>Estado de Situación Financiera</strong> y un
             <strong>Estado de Resultados</strong> para poder generar el análisis completo.
           </p>
         </div>
@@ -1125,7 +1125,7 @@ async function generateAnalysis() {
               <div class="doc-left">
                 <span class="material-symbols-outlined">description</span>
                 <div>
-                  <p class="doc-title">Balance General</p>
+                  <p class="doc-title">Estado de Situación Financiera</p>
                   <p class="doc-sub">
                     <span v-if="p.balanceFile" class="file-success">
                       {{ p.balanceFile.name }}

--- a/frontend/src/views/CargaDeDocumentosView.vue
+++ b/frontend/src/views/CargaDeDocumentosView.vue
@@ -635,7 +635,62 @@ async function removePeriod(periodId) {
 // =====================
 // ANÁLISIS
 // =====================
-function getColIndex(period) {
+
+// Normaliza periodDate al formato que devuelve el backend en /detect-columns:
+//   anual      → "2024"
+//   mensual    → "2024-01"
+//   trimestral → "2024-Q1"
+function getPeriodKey(period) {
+  if (!period.periodDate) return null;
+  const dateStr = String(period.periodDate);
+
+  if (periodicity.value === "anual") {
+    const yearMatch = dateStr.match(/\b(20\d{2})\b/);
+    return yearMatch ? yearMatch[1] : null;
+  }
+
+  const parts = dateStr.split("-");
+  if (parts.length < 2) return null;
+
+  const year = parts[0];
+  const month = parts[1].padStart(2, "0");
+
+  if (periodicity.value === "mensual") {
+    return `${year}-${month}`;
+  }
+
+  if (periodicity.value === "trimestral") {
+    const q = Math.ceil(parseInt(month, 10) / 3);
+    return `${year}-Q${q}`;
+  }
+
+  return null;
+}
+
+// Llama al backend para obtener el mapa {periodo: col_index} a partir de los headers reales.
+// Si falla (red, OCR, etc.), devuelve null y el caller cae al fallback.
+async function detectColumnsForPeriod(period) {
+  try {
+    const response = await fetch(`${API_BASE_URL}/documents/detect-columns`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        balance_url: period.balanceFile.url,
+        resultados_url: period.resultsFile.url,
+      }),
+    });
+
+    if (!response.ok) return null;
+    return await response.json();
+  } catch (error) {
+    console.warn("Detección de columnas falló:", error);
+    return null;
+  }
+}
+
+// Fallback histórico: deduce el col_index a partir de la fecha que indicó el usuario,
+// asumiendo orden cronológico estándar. Se usa solo cuando la detección por backend no encuentra el periodo.
+function getColIndexFallback(period) {
   let indiceColumna = 0;
 
   if (periodicity.value === "mensual" && period.periodDate) {
@@ -683,6 +738,27 @@ function getColIndex(period) {
   return indiceColumna;
 }
 
+// Resuelve el col_index correcto para un periodo.
+// Estrategia: primero pregunta al backend qué columna corresponde al periodo solicitado
+// (basado en los headers reales del documento). Si el backend no encuentra el periodo en
+// ningún documento, cae al fallback histórico que deduce por orden cronológico.
+async function getColIndex(period) {
+  const periodKey = getPeriodKey(period);
+  if (!periodKey) return getColIndexFallback(period);
+
+  const detected = await detectColumnsForPeriod(period);
+  if (!detected) return getColIndexFallback(period);
+
+  if (detected.balance && detected.balance[periodKey] !== undefined) {
+    return detected.balance[periodKey];
+  }
+  if (detected.resultados && detected.resultados[periodKey] !== undefined) {
+    return detected.resultados[periodKey];
+  }
+
+  return getColIndexFallback(period);
+}
+
 async function analyzePeriod(period) {
   const payload = {
     project_id: projectId,
@@ -690,7 +766,7 @@ async function analyzePeriod(period) {
     balance_url: period.balanceFile.url,
     resultados_url: period.resultsFile.url,
     periodicidad: periodicity.value,
-    col_index: getColIndex(period),
+    col_index: await getColIndex(period),
     period_date: period.periodDate,
     period_label: period.label,
   };

--- a/frontend/src/views/EndeudamientoMultiperiodoView.vue
+++ b/frontend/src/views/EndeudamientoMultiperiodoView.vue
@@ -474,7 +474,7 @@ onMounted(() => {
       <div class="subtitle">
         <p>Analiza la solvencia y el riesgo financiero a largo plazo</p>
         <span class="dot" aria-hidden="true">•</span>
-        <p class="small">Indicadores calculados a partir del Balance General y Estado de Resultados</p>
+        <p class="small">Indicadores calculados a partir del Estado de Situación Financiera y Estado de Resultados</p>
       </div>
     </div>
 

--- a/frontend/src/views/EndeudamientoView.vue
+++ b/frontend/src/views/EndeudamientoView.vue
@@ -181,7 +181,7 @@ onMounted(() => {
       <div class="subtitle">
         <p>Nivel de apalancamiento y estabilidad financiera de la empresa</p>
         <span class="dot" aria-hidden="true">•</span>
-        <p class="small">Indicadores calculados a partir del Balance General y Estado de Resultados</p>
+        <p class="small">Indicadores calculados a partir del Estado de Situación Financiera y Estado de Resultados</p>
       </div>
     </div>
 

--- a/frontend/src/views/EstructuraMultiView.vue
+++ b/frontend/src/views/EstructuraMultiView.vue
@@ -481,7 +481,7 @@ onMounted(() => {
       <div class="subtitle">
         <p>Composición del capital y estabilidad financiera de la empresa</p>
         <span class="dot" aria-hidden="true">•</span>
-        <p class="small">Indicadores calculados a partir del Balance General</p>
+        <p class="small">Indicadores calculados a partir del Estado de Situación Financiera</p>
       </div>
     </div>
 

--- a/frontend/src/views/EstructuraMultiView.vue
+++ b/frontend/src/views/EstructuraMultiView.vue
@@ -471,7 +471,7 @@ onMounted(() => {
   <div class="wrap" v-if="!loading && metrics.length > 0">
     <div class="title">
       <div class="title-row">
-        <h1>Estructura Financiera</h1>
+        <h1>Estructura financiera</h1>
         <button class="btn-learn" type="button" @click="centroDeAprendizaje">
           <span class="material-symbols-outlined">info</span>
           <span>Ir a centro de aprendizaje</span>

--- a/frontend/src/views/EstructuraView.vue
+++ b/frontend/src/views/EstructuraView.vue
@@ -181,7 +181,7 @@ onMounted(() => {
     <!-- TITULO -->
     <div class="title">
       <div class="title-row">
-        <h1>Estructura Financiera</h1>
+        <h1>Estructura financiera</h1>
 
         <button class="btn-learn" type="button" @click="centroDeAprendizaje">
           <span class="material-symbols-outlined">info</span>

--- a/frontend/src/views/EstructuraView.vue
+++ b/frontend/src/views/EstructuraView.vue
@@ -192,7 +192,7 @@ onMounted(() => {
       <div class="subtitle">
         <p>Diagnóstico de la composición del capital</p>
         <span class="dot" aria-hidden="true">•</span>
-        <p class="small">Indicadores calculados a partir del Balance General</p>
+        <p class="small">Indicadores calculados a partir del Estado de Situación Financiera</p>
       </div>
     </div>
 

--- a/frontend/src/views/LiquidezMultiperiodoView.vue
+++ b/frontend/src/views/LiquidezMultiperiodoView.vue
@@ -443,7 +443,7 @@ onMounted(() => {
       <div class="subtitle">
         <p>Capacidad de la empresa para cumplir con sus obligaciones a corto plazo</p>
         <span class="dot" aria-hidden="true">•</span>
-        <p class="small">Indicadores calculados a partir del Balance General</p>
+        <p class="small">Indicadores calculados a partir del Estado de Situación Financiera</p>
       </div>
     </div>
 

--- a/frontend/src/views/LiquidezView.vue
+++ b/frontend/src/views/LiquidezView.vue
@@ -172,7 +172,7 @@ onMounted(() => {
       <div class="subtitle">
         <p>Capacidad de la empresa para cumplir con sus obligaciones a corto plazo</p>
         <span class="dot" aria-hidden="true">•</span>
-        <p class="small">Indicadores calculados a partir del Balance General</p>
+        <p class="small">Indicadores calculados a partir del Estado de Situación Financiera</p>
       </div>
     </div>
 

--- a/frontend/src/views/MisProyectosView.vue
+++ b/frontend/src/views/MisProyectosView.vue
@@ -87,19 +87,21 @@ const onboardingChecking = ref(true);
 const onboardingSlides = [
   {
     title: "Bienvenido a PymeScope",
-  text: `Estamos felices de tenerte aquí :)
+    text: `Estamos felices de tenerte aquí :)
 Tus datos están seguros en todo momento.
-PymeScope puede cometer errores, así que consulta a un profesional calificado para obtener asesoramiento financiero.`,    icon: "waving_hand",
+PymeScope es un prototipo en desarrollo, por lo que te recomendamos verificar los resultados con un profesional financiero calificado.`,
+    icon: "waving_hand",
   },
   {
     title: "Sube tus archivos",
-    text: "Sube tus archivos de Balance General y Estado de Resultados. Nuestro sistema extraerá los datos automáticamente para generar tu dashboard financiero.",
+    text: "Sube tus archivos de Estado de Situación Financiera y Estado de Resultados. Nuestro sistema extraerá los datos automáticamente para generar tu dashboard financiero.",
     icon: "cloud_upload",
   },
-{
+  {
     title: "Formato de Archivos",
     icon: "description",
     bullets: [
+      "Solo se aceptan archivos en formato PDF.",
       "Evita usar abreviaturas en los nombres de las cuentas.",
       "Incluye sumas totales para cada categoría.",
       "Mantén una estructura clara y consistente.",
@@ -549,7 +551,7 @@ async function guardarNombre(p) {
     <main class="container main">
       <div class="top">
         <div class="top-left">
-          <h2>Mis proyectos de análisis</h2>
+          <h2>Mis proyectos de análisis financiero</h2>
           <p>Crea y administra tus análisis financieros en un solo lugar.</p>
         </div>
 

--- a/frontend/src/views/RentabilidadMultiperiodoView.vue
+++ b/frontend/src/views/RentabilidadMultiperiodoView.vue
@@ -109,6 +109,14 @@ const generateDashboardData = () => {
     return item ? item.status : "warn";
   };
 
+  const getKpiNota = (kpis, keyword) => {
+    if (!kpis) return null;
+    const item = kpis.find((k) =>
+      k.label.toLowerCase().includes(keyword.toLowerCase())
+    );
+    return item?.nota_periodo || null;
+  };
+
   const dataMargen = periods.map((p) => findKpi(p.rentabilidad.kpis, "margen"));
   const dataRat = periods.map((p) => findKpi(p.rentabilidad.kpis, "activos"));
   const dataRoe = periods.map((p) => findKpi(p.rentabilidad.kpis, "patrimonio"));
@@ -197,6 +205,7 @@ const generateDashboardData = () => {
         "rat",
         getKpiStatus(lastP.rentabilidad.kpis, "activos")
       ),
+      notaPeriodo: getKpiNota(lastP.rentabilidad.kpis, "activos"),
     },
     {
       key: "roe",
@@ -209,6 +218,7 @@ const generateDashboardData = () => {
         "roe",
         getKpiStatus(lastP.rentabilidad.kpis, "patrimonio")
       ),
+      notaPeriodo: getKpiNota(lastP.rentabilidad.kpis, "patrimonio"),
     },
   ];
 
@@ -455,6 +465,7 @@ onMounted(() => {
         </div>
 
         <div class="kpi-value">{{ k.kpiValue }}</div>
+        <p v-if="k.notaPeriodo" class="kpi-nota">{{ k.notaPeriodo }}</p>
 
         <div class="kpi-delta">
           <span class="delta-pill" :class="k.deltaType === 'up' ? 'delta-up' : 'delta-down'">
@@ -949,6 +960,14 @@ onMounted(() => {
   font-size: 24px;
   font-weight: 900;
   color: #0e161b;
+}
+
+.kpi-nota {
+  margin: 2px 0 0;
+  font-size: 11px;
+  font-weight: 500;
+  color: #94a3b8;
+  font-style: italic;
 }
 
 .kpi-delta {

--- a/frontend/src/views/RentabilidadView.vue
+++ b/frontend/src/views/RentabilidadView.vue
@@ -194,6 +194,7 @@ onMounted(async () => {
           </div>
 
           <div class="kpi-value">{{ k.value }}</div>
+          <p v-if="k.nota_periodo" class="kpi-nota">{{ k.nota_periodo }}</p>
         </article>
       </section>
 
@@ -507,6 +508,14 @@ onMounted(async () => {
   font-size: 24px;
   font-weight: 900;
   color: #0e161b;
+}
+
+.kpi-nota {
+  margin: 2px 0 0;
+  font-size: 11px;
+  font-weight: 500;
+  color: #94a3b8;
+  font-style: italic;
 }
 
 /* Panel + table */

--- a/frontend/src/views/ResumenGeneralMonoView.vue
+++ b/frontend/src/views/ResumenGeneralMonoView.vue
@@ -973,12 +973,21 @@ const mapDataToDashboard = (data) => {
     },
   ];
 
+  const findKpiNota = (kpis, keyword) => {
+    if (!kpis) return null;
+    const item = kpis.find((k) =>
+      k.label.toLowerCase().includes(keyword.toLowerCase())
+    );
+    return item?.nota_periodo || null;
+  };
+
   cards.value[0].items = [
     {
       label: "ROE",
       target: ">10%",
       value: findKpiValue(rent.kpis, "Patrimonio") || "-",
       dot: getDotColor(rent.kpis, "Patrimonio"),
+      nota: findKpiNota(rent.kpis, "Patrimonio"),
     },
     {
       label: "Margen Neto",
@@ -1033,6 +1042,7 @@ const mapDataToDashboard = (data) => {
       target: ">4.0x",
       value: rotInvValue,
       dot: getDotColor(rot.kpis, "Inventarios"),
+      nota: findKpiNota(rot.kpis, "Inventarios"),
     },
     {
       label: "Periodo Cobro",
@@ -1195,6 +1205,7 @@ onMounted(() => {
 
             <div class="metric-right">
               <p class="metric-value">{{ it.value }}</p>
+              <p v-if="it.nota" class="metric-nota">{{ it.nota }}</p>
               <span class="mini-dot" :class="it.dot" aria-hidden="true"></span>
             </div>
 
@@ -1521,6 +1532,14 @@ onMounted(() => {
 .metric-value {
   margin: 0;
   font-weight: 900;
+}
+
+.metric-nota {
+  margin: 0;
+  font-size: 10px;
+  font-weight: 500;
+  color: #94a3b8;
+  font-style: italic;
 }
 
 .mini-dot {

--- a/frontend/src/views/RotacionDeActivosMultiView.vue
+++ b/frontend/src/views/RotacionDeActivosMultiView.vue
@@ -553,7 +553,7 @@ onMounted(() => {
       <div class="subtitle">
         <p>Análisis de eficiencia operativa y administración de activos</p>
         <span class="dot" aria-hidden="true">•</span>
-        <p class="small">Indicadores calculados a partir del Balance General y del Estado de Resultados</p>
+        <p class="small">Indicadores calculados a partir del Estado de Situación Financiera y del Estado de Resultados</p>
       </div>
     </div>
 

--- a/frontend/src/views/RotacionDeActivosMultiView.vue
+++ b/frontend/src/views/RotacionDeActivosMultiView.vue
@@ -116,6 +116,14 @@ const generateDashboardData = () => {
     return item ? item.status : "warn";
   };
 
+  const getKpiNota = (kpis, keyword) => {
+    if (!kpis) return null;
+    const item = kpis.find((k) =>
+      k.label.toLowerCase().includes(keyword.toLowerCase())
+    );
+    return item?.nota_periodo || null;
+  };
+
   const dataCobrar = periods.map((p) => findKpi(p.rotacion.kpis, "cartera"));
   const dataRecaudo = periods.map((p) => findKpi(p.rotacion.kpis, "recaudo"));
   const dataInventarios = periods.map((p) =>
@@ -231,6 +239,7 @@ const generateDashboardData = () => {
         "times",
         getKpiStatus(lastP.rotacion.kpis, "cartera")
       ),
+      notaPeriodo: getKpiNota(lastP.rotacion.kpis, "cartera"),
     },
     {
       key: "recaudo",
@@ -255,6 +264,7 @@ const generateDashboardData = () => {
         "times",
         getKpiStatus(lastP.rotacion.kpis, "inventarios")
       ),
+      notaPeriodo: getKpiNota(lastP.rotacion.kpis, "inventarios"),
     },
     {
       key: "fijos",
@@ -267,6 +277,7 @@ const generateDashboardData = () => {
         "times",
         getKpiStatus(lastP.rotacion.kpis, "fijos")
       ),
+      notaPeriodo: getKpiNota(lastP.rotacion.kpis, "fijos"),
     },
     {
       key: "activosTotales",
@@ -279,6 +290,7 @@ const generateDashboardData = () => {
         "times",
         getKpiStatus(lastP.rotacion.kpis, "totales")
       ),
+      notaPeriodo: getKpiNota(lastP.rotacion.kpis, "totales"),
     },
   ];
 
@@ -562,6 +574,7 @@ onMounted(() => {
         </div>
 
         <div class="kpi-value">{{ k.kpiValue }}</div>
+        <p v-if="k.notaPeriodo" class="kpi-nota">{{ k.notaPeriodo }}</p>
 
         <div class="kpi-delta">
           <span
@@ -1071,6 +1084,14 @@ onMounted(() => {
   font-size: 24px;
   font-weight: 900;
   color: #0e161b;
+}
+
+.kpi-nota {
+  margin: 2px 0 0;
+  font-size: 11px;
+  font-weight: 500;
+  color: #94a3b8;
+  font-style: italic;
 }
 
 .kpi-delta {

--- a/frontend/src/views/RotacionDeActivosMultiView.vue
+++ b/frontend/src/views/RotacionDeActivosMultiView.vue
@@ -543,7 +543,7 @@ onMounted(() => {
   <div class="wrap" v-if="!loading && metrics.length > 0">
     <div class="title">
       <div class="title-row">
-        <h1>Rotación de Activos</h1>
+        <h1>Rotación de activos</h1>
         <button class="btn-learn" type="button" @click="centroDeAprendizaje">
           <span class="material-symbols-outlined">info</span>
           <span>Ir a centro de aprendizaje</span>

--- a/frontend/src/views/RotacionDeActivosView.vue
+++ b/frontend/src/views/RotacionDeActivosView.vue
@@ -184,7 +184,7 @@ onMounted(() => {
       <div class="subtitle">
         <p>Diagnóstico de eficiencia operativa</p>
         <span class="dot" aria-hidden="true">•</span>
-        <p class="small">Indicadores calculados a partir del Balance General y Estado de Resultados</p>
+        <p class="small">Indicadores calculados a partir del Estado de Situación Financiera y Estado de Resultados</p>
       </div>
     </div>
 

--- a/frontend/src/views/RotacionDeActivosView.vue
+++ b/frontend/src/views/RotacionDeActivosView.vue
@@ -173,7 +173,7 @@ onMounted(() => {
     <!-- TITULO -->
     <div class="title">
       <div class="title-row">
-        <h1>Rotación de Activos</h1>
+        <h1>Rotación de activos</h1>
 
         <button class="btn-learn" type="button" @click="centroDeAprendizaje">
           <span class="material-symbols-outlined">info</span>

--- a/frontend/src/views/RotacionDeActivosView.vue
+++ b/frontend/src/views/RotacionDeActivosView.vue
@@ -202,6 +202,7 @@ onMounted(() => {
           </div>
 
           <div class="kpi-value">{{ k.value }}</div>
+          <p v-if="k.nota_periodo" class="kpi-nota">{{ k.nota_periodo }}</p>
         </article>
       </section>
 
@@ -513,6 +514,14 @@ onMounted(() => {
   font-size: 24px;
   font-weight: 900;
   margin-top: 10px;
+}
+
+.kpi-nota {
+  margin: 2px 0 0;
+  font-size: 11px;
+  font-weight: 500;
+  color: #94a3b8;
+  font-style: italic;
 }
 
 /* PANEL + TABLE */


### PR DESCRIPTION
Bug 1 — Selección de columna incorrecta en comparativos multi-año:
El motor siempre devolvía los valores del año más antiguo al analizar estados financieros comparativos (ej. 2025 vs 2024). La causa era que `take_last`, una heurística legada, tenía prioridad sobre `col_index` (la columna detectada explícitamente por el motor). Se corrigió el orden de evaluación en los dos caminos de extracción (`_keyword_search` y `_semantic_search`): ahora `col_index` es la fuente de verdad y `take_last` solo actúa como fallback cuando la columna queda fuera de rango.

Bug 2 — Subtotales en cero en layouts sin líneas de total explícitas (cooperativas)**
Se implementó un mecanismo de rescate por suma de subcuentas: si un subtotal es 0, el motor intenta reconstruirlo sumando sus componentes individuales (efectivo + clientes + inventario + anticipos, etc.). El rescate solo activa si al menos una subcuenta tiene valor, evitando falsos positivos.

Frontend — mejoras de UX y corrección de datos

- **Terminología:** "Balance General" renombrado a "Estado de Situación Financiera" en todas las vistas de análisis, carga de documentos y onboarding (las vistas de proyecciones proforma mantienen el término por contexto).
- **Onboarding:** reformulado el mensaje de la pantalla de bienvenida para comunicar correctamente que es un prototipo en desarrollo; agregado el requisito de formato PDF en el paso de formato de archivos.
- **Mi perfil:** eliminado el encabezado "Zona de peligro" del modal de perfil.
- **Mis proyectos:** renombrado a "Mis proyectos de análisis financiero".
- **Bug de archivos:** al eliminar un archivo de un proyecto analizado y recargar la página, el archivo reaparecía. Causa: `setDoc` con `null` y `merge: true` no garantiza limpiar el campo en Firestore. Fix: se usa `deleteField()` para eliminar el campo explícitamente.